### PR TITLE
feat(poker-sym): add omaha hi simulation support

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,5 @@
     "typedoc": "^0.28.14",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
-  },
-  "dependencies": {}
+  }
 }

--- a/poker-sym/README.md
+++ b/poker-sym/README.md
@@ -4,20 +4,23 @@ Monte Carlo simulation tool for evaluating poker starting hand strength. Part of
 
 ## Overview
 
-`poker-sym` uses Monte Carlo simulation to rank starting hands by their preflop equity. Currently supports **Texas Hold'em** with more variants planned.
+`poker-sym` uses Monte Carlo simulation to rank starting hands by their preflop equity. Currently supports **Texas Hold'em** and **Omaha Hi**.
 
 Each simulation:
-1. Enumerates all **169 canonical starting hands** (13 pairs + 78 suited + 78 offsuit)
+1. Enumerates all canonical starting hands (169 for Hold'em, 9,854 for Omaha)
 2. For each hand, runs N random board completions
-3. Evaluates the resulting 7-card hand using the gamblingjs evaluator
+3. Evaluates the resulting 7-card or 5-card best hand using the gamblingjs evaluator
 4. Calculates win/tie percentages against opponents
 5. Ranks all hands and assigns tier classifications
 
 ## Quick Start
 
 ```bash
-# From the poker-sym directory
+# From the poker-sym directory (Texas Hold'em by default)
 npx tsx src/cli.ts --runs 10000 --opponents 1 --format table
+
+# Omaha Hi simulation
+npx tsx src/cli.ts --game omaha --runs 1000 --opponents 1 --format table
 
 # Raw hand strength (no opponents)
 npx tsx src/cli.ts --runs 50000 --format md
@@ -33,11 +36,14 @@ npx tsx src/cli.ts --runs 10000 --seed 42 --format csv
 
 | Option | Alias | Default | Description |
 |--------|-------|---------|-------------|
+| `--game` | `-g` | holdem | Game variant: `holdem` or `omaha` |
 | `--runs` | `-n` | 10000 | Simulation runs per hand |
 | `--opponents` | `-o` | 0 | Number of opponents (0 = raw strength) |
 | `--seed` | `-s` | random | Random seed for reproducibility |
 | `--format` | `-f` | table | Output format: `table`, `json`, `csv`, `md` |
 | `--output` | `-O` | stdout | Write output to file |
+
+⚠️ **Note on Omaha Simulation Time:** Omaha has ~9,854 canonical hands and requires evaluating 60 combinations per player per iteration. Simulations will take significantly longer than Hold'em. Use `-n` to lower the iterations if necessary.
 
 ## Output Formats
 

--- a/poker-sym/src/cli.ts
+++ b/poker-sym/src/cli.ts
@@ -5,6 +5,7 @@ import { HighEvaluator } from '../../src/core/HighEvaluator.js';
 import { handOfFiveEvalIndexed } from '../../src/pokerEvaluator5.js';
 import { fastHashesCreators } from '../../src/pokerHashes7.js';
 import { rankHoldemStartingHands } from './ranking/ranker.js';
+import { rankOmahaStartingHands } from './ranking/omaha-ranker.js';
 import { rankStreets } from './ranking/street-ranker.js';
 import { SimulationConfig } from './simulation/types.js';
 import { formatTable, formatJSON, formatCSV, formatMarkdown } from './output.js';
@@ -20,8 +21,9 @@ const program = new Command();
 
 program
   .name('poker-sym')
-  .description('Monte Carlo simulation for poker starting hand ranking')
+  .description('Monte Carlo simulation for poker starting hand ranking (Hold\'em, Omaha)')
   .version('0.1.0')
+  .option('-g, --game <type>', 'game variant: holdem, omaha', 'holdem')
   .option('-n, --runs <number>', 'number of simulation runs per hand', '10000')
   .option('-o, --opponents <number>', 'number of opponents (0 = raw strength)', '0')
   .option('-s, --seed <number>', 'random seed for reproducibility')
@@ -37,6 +39,7 @@ program
       useCache: true,
     };
 
+    const game = options.game?.toLowerCase() ?? 'holdem';
     const format = options.format as string;
     const outputFile = options.output as string | undefined;
     const streetMode = options.street as boolean | undefined;
@@ -51,58 +54,20 @@ program
 
     const startTime = Date.now();
 
-    if (streetMode) {
-      // Street-by-street analysis mode
-      console.error(
-        `Running Texas Hold'em street-by-street analysis...\n` +
-          `  Hands: 169 | Runs/hand: ${config.runs}`,
-      );
-
-      const result = rankStreets(
-        handOfFiveEvalIndexed,
-        evalFn7,
-        config.runs,
-        config.seed,
-        (completed, total, hand) => {
-          if (completed % 10 === 0 || completed === total) {
-            const pct = ((completed / total) * 100).toFixed(0);
-            process.stderr.write(`\r  Progress: ${completed}/${total} (${pct}%) — ${hand}    `);
-          }
-        },
-      );
-
-      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-      process.stderr.write(`\n  Completed in ${elapsed}s\n`);
-
-      let output: string;
-      switch (format) {
-        case 'json':
-          output = formatStreetJSON(result);
-          break;
-        case 'csv':
-          output = formatStreetCSV(result);
-          break;
-        case 'md':
-          output = formatStreetMarkdown(result);
-          break;
-        default:
-          output = detailed ? formatStreetTableDetailed(result) : formatStreetTable(result);
+    if (game === 'omaha') {
+      if (streetMode) {
+        console.error('Street analysis for Omaha is not yet supported.');
+        process.exit(1);
       }
 
-      if (outputFile) {
-        fs.writeFileSync(outputFile, output, 'utf-8');
-        console.error(`\nResults written to ${outputFile}`);
-      } else {
-        console.log(output);
-      }
-    } else {
-      // Original preflop simulation mode
       console.error(
-        `Running Texas Hold'em preflop simulation...\n` +
-          `  Hands: 169 | Runs/hand: ${config.runs} | Opponents: ${config.opponents}`,
+        `Running Omaha Hi preflop simulation...\n` +
+          `  Note: Omaha simulation involves ~9,854 hands and 60 combinations per evaluation.\n` +
+          `  This will take significantly longer than Hold'em. Use -n to reduce iterations if needed.\n` +
+          `  Runs/hand: ${config.runs} | Opponents: ${config.opponents}`,
       );
 
-      const result = rankHoldemStartingHands(evalFn7, config, (completed, total, hand) => {
+      const result = rankOmahaStartingHands({ eval5: handOfFiveEvalIndexed }, config, (completed, total, hand) => {
         if (completed % 10 === 0 || completed === total) {
           const pct = ((completed / total) * 100).toFixed(0);
           process.stderr.write(`\r  Progress: ${completed}/${total} (${pct}%) — ${hand}    `);
@@ -132,6 +97,90 @@ program
         console.error(`\nResults written to ${outputFile}`);
       } else {
         console.log(output);
+      }
+    } else {
+      if (streetMode) {
+        // Street-by-street analysis mode
+        console.error(
+          `Running Texas Hold'em street-by-street analysis...\n` +
+            `  Hands: 169 | Runs/hand: ${config.runs}`,
+        );
+
+        const result = rankStreets(
+          handOfFiveEvalIndexed,
+          evalFn7,
+          config.runs,
+          config.seed,
+          (completed, total, hand) => {
+            if (completed % 10 === 0 || completed === total) {
+              const pct = ((completed / total) * 100).toFixed(0);
+              process.stderr.write(`\r  Progress: ${completed}/${total} (${pct}%) — ${hand}    `);
+            }
+          },
+        );
+
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        process.stderr.write(`\n  Completed in ${elapsed}s\n`);
+
+        let output: string;
+        switch (format) {
+          case 'json':
+            output = formatStreetJSON(result);
+            break;
+          case 'csv':
+            output = formatStreetCSV(result);
+            break;
+          case 'md':
+            output = formatStreetMarkdown(result);
+            break;
+          default:
+            output = detailed ? formatStreetTableDetailed(result) : formatStreetTable(result);
+        }
+
+        if (outputFile) {
+          fs.writeFileSync(outputFile, output, 'utf-8');
+          console.error(`\nResults written to ${outputFile}`);
+        } else {
+          console.log(output);
+        }
+      } else {
+        // Original preflop simulation mode
+        console.error(
+          `Running Texas Hold'em preflop simulation...\n` +
+            `  Hands: 169 | Runs/hand: ${config.runs} | Opponents: ${config.opponents}`,
+        );
+
+        const result = rankHoldemStartingHands(evalFn7, config, (completed, total, hand) => {
+          if (completed % 10 === 0 || completed === total) {
+            const pct = ((completed / total) * 100).toFixed(0);
+            process.stderr.write(`\r  Progress: ${completed}/${total} (${pct}%) — ${hand}    `);
+          }
+        });
+
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        process.stderr.write(`\n  Completed in ${elapsed}s\n`);
+
+        let output: string;
+        switch (format) {
+          case 'json':
+            output = formatJSON(result);
+            break;
+          case 'csv':
+            output = formatCSV(result);
+            break;
+          case 'md':
+            output = formatMarkdown(result);
+            break;
+          default:
+            output = formatTable(result);
+        }
+
+        if (outputFile) {
+          fs.writeFileSync(outputFile, output, 'utf-8');
+          console.error(`\nResults written to ${outputFile}`);
+        } else {
+          console.log(output);
+        }
       }
     }
   });

--- a/poker-sym/src/hands/omaha-canonical.ts
+++ b/poker-sym/src/hands/omaha-canonical.ts
@@ -1,0 +1,197 @@
+import { cardIndex, cardRank, cardSuit } from '../utils/deck.js';
+import { OmahaRankPattern, OmahaSuitPattern } from './types.js';
+import { rankSym } from './canonical.js';
+
+/**
+ * Extracts ranks and sorts them in descending order.
+ */
+export const getSortedRanks = (cards: number[]): number[] => {
+  return cards.map(cardRank).sort((a, b) => b - a);
+};
+
+/**
+ * Compute the rank pattern for a 4-card Omaha hand.
+ */
+export const omahaRankPattern = (cards: number[]): OmahaRankPattern => {
+  const ranks = getSortedRanks(cards);
+  const counts: Record<number, number> = {};
+  for (const r of ranks) {
+    counts[r] = (counts[r] || 0) + 1;
+  }
+  const vals = Object.values(counts).sort((a, b) => b - a);
+
+  if (vals[0] === 4) return OmahaRankPattern.QUADS;
+  if (vals[0] === 3) return OmahaRankPattern.TRIPS;
+  if (vals[0] === 2 && vals[1] === 2) return OmahaRankPattern.TWO_PAIR;
+  if (vals[0] === 2) return OmahaRankPattern.ONE_PAIR;
+  return OmahaRankPattern.HIGH;
+};
+
+/**
+ * Compute the suit pattern for a 4-card Omaha hand.
+ */
+export const omahaSuitPattern = (cards: number[]): OmahaSuitPattern => {
+  const suits = cards.map(cardSuit);
+  const counts: Record<number, number> = {};
+  for (const s of suits) {
+    counts[s] = (counts[s] || 0) + 1;
+  }
+  const vals = Object.values(counts).sort((a, b) => b - a);
+
+  if (vals[0] === 4) return OmahaSuitPattern.MONOSUIT;
+  if (vals[0] === 3) return OmahaSuitPattern.THREE_ONE;
+  if (vals[0] === 2 && vals[1] === 2) return OmahaSuitPattern.DOUBLE_SUITED;
+  if (vals[0] === 2 && vals[1] === 1) return OmahaSuitPattern.TWO_ONE_ONE;
+  return OmahaSuitPattern.RAINBOW;
+};
+
+/**
+ * Generates an Omaha hand key based on ranks and suit distribution.
+ * Sorts ranks to enforce a descending canonical representation.
+ */
+export const omahaKey = (cards: number[]): string => {
+  // Sort cards primarily by rank (desc), then by a canonical suit order to ensure isomorphic groupings get identical keys.
+  // Actually, we need to identify the exact suit configuration relative to the ranks.
+
+  // Group cards by rank, ordered highest rank to lowest
+  const cardsByRank: Record<number, number[]> = {};
+  for (const c of cards) {
+    const r = cardRank(c);
+    if (!cardsByRank[r]) cardsByRank[r] = [];
+    cardsByRank[r].push(c);
+  }
+
+  // We want to sort the rank keys descending
+  const sortedRankKeys = Object.keys(cardsByRank).map(Number).sort((a, b) => b - a);
+
+  // Construct the rank part (e.g. AAAA, AAKK, AKQJ)
+  let rankStr = '';
+  // Ordered flat list of cards matching the rankStr
+  const orderedCards: number[] = [];
+
+  // For rank patterns where multiplicities are different (e.g. Trips AAAB vs ABBB),
+  // we want the trips to come first in the rank string, but wait, poker standard
+  // is usually just highest to lowest, except maybe for full houses/etc.
+  // Actually, for canonical keys, sorting the rank groups by descending frequency,
+  // then descending rank is the most standard way (e.g. AAAB, not BAAA even if B is A and A is K).
+
+  // Custom sort for rank groups: frequency desc, then rank desc
+  const rankGroups = sortedRankKeys.map(r => ({ rank: r, cards: cardsByRank[r]! }));
+  rankGroups.sort((a, b) => {
+    if (a.cards.length !== b.cards.length) return b.cards.length - a.cards.length;
+    return b.rank - a.rank;
+  });
+
+  for (const group of rankGroups) {
+    for (const c of group.cards) {
+      rankStr += rankSym(group.rank);
+      orderedCards.push(c);
+    }
+  }
+
+  // Now determine the suit suffix.
+  const rPattern = omahaRankPattern(cards);
+  const sPattern = omahaSuitPattern(cards);
+
+  let suitSuffix = '';
+
+  // Helper to get suit of ordered card i
+  const s = (i: number) => cardSuit(orderedCards[i]!);
+
+  switch (rPattern) {
+    case OmahaRankPattern.QUADS:
+      // AAAA - suit pattern doesn't matter (always rainbow)
+      break;
+
+    case OmahaRankPattern.TRIPS:
+      // AAAB (orderedCards 0,1,2 are the trips, 3 is the kicker)
+      // Trips use 3 of the 4 suits.
+      // Suffix: 's' if kicker is suited to one of the trips, 'o' if it's the remaining 4th suit.
+      // Since orderedCards 0,1,2 contain 3 distinct suits, kicker is suited if its suit is in {s(0),s(1),s(2)}
+      if (s(3) === s(0) || s(3) === s(1) || s(3) === s(2)) {
+        suitSuffix = ':s'; // Kicker suited
+      } else {
+        suitSuffix = ':o'; // Kicker offsuit
+      }
+      break;
+
+    case OmahaRankPattern.TWO_PAIR:
+      // AABB
+      if (sPattern === OmahaSuitPattern.DOUBLE_SUITED) {
+        // AABB where suits match exactly (e.g., AsKs, AhKh).
+        if ((s(0) === s(2) && s(1) === s(3)) || (s(0) === s(3) && s(1) === s(2))) {
+           suitSuffix = ':ss'; // Share both suits
+        } else {
+           suitSuffix = ':ns'; // Share no suits (should be impossible to be ds but share no suits for AABB?
+           // Wait. If AABB is ds, that means 2 of suit X, 2 of suit Y.
+           // They MUST either be (X,X)+(Y,Y) or (X,Y)+(X,Y).
+           // (X,X) + (Y,Y) means pairs don't share suits, so A1=X,A2=X; B1=Y,B2=Y. This is impossible since A1,A2 must have DIFFERENT suits.
+           // Thus, AABB ds is ALWAYS (X,Y)+(X,Y). So AABB:ds means they share BOTH suits.
+           suitSuffix = ':ss';
+        }
+      } else if (sPattern === OmahaSuitPattern.RAINBOW) {
+         // All 4 different suits
+         suitSuffix = ':ns'; // Share no suits
+      } else {
+         // sPattern is TWO_ONE_ONE (since AABB cannot be Mono or Three-One)
+         // Meaning 2 of suit X, 1 of Y, 1 of Z.
+         // This means they share EXACTLY ONE suit.
+         suitSuffix = ':s1';
+      }
+      break;
+
+    case OmahaRankPattern.ONE_PAIR:
+      // AABC
+      // Pair is at 0, 1. Kickers at 2, 3.
+      if (sPattern === OmahaSuitPattern.MONOSUIT) {
+         suitSuffix = ':ms'; // Impossible, pair has different suits
+      } else if (sPattern === OmahaSuitPattern.THREE_ONE) {
+         // Three of suit X, one of Y.
+         // Suit X must be shared by one of the pair cards and BOTH kickers.
+         suitSuffix = ':31';
+      } else if (sPattern === OmahaSuitPattern.DOUBLE_SUITED) {
+         // X, X, Y, Y
+         // Pair has suits {X,Y}. Kickers must have suits {X,Y}.
+         // Which means kickers are suited to DIFFERENT pair suits.
+         suitSuffix = ':ds';
+      } else if (sPattern === OmahaSuitPattern.RAINBOW) {
+         suitSuffix = ':rb'; // Both kickers offsuit to everything
+      } else {
+         // TWO_ONE_ONE: X, X, Y, Z
+         // Several possibilities:
+         // 1. Kickers match each other (Z, Z). Since pair is X,Y, kickers don't match pair. (e.g. AsAh KcQc) -> ':ks' (kickers suited)
+         // 2. One kicker matches pair, other is new suit. (e.g. AsAh KsQd) -> ':s1' (one kicker suited to pair)
+         if (s(2) === s(3)) {
+            suitSuffix = ':ks';
+         } else {
+            suitSuffix = ':s1';
+         }
+      }
+      break;
+
+    case OmahaRankPattern.HIGH:
+      // ABCD
+      if (sPattern === OmahaSuitPattern.MONOSUIT) suitSuffix = ':ms';
+      else if (sPattern === OmahaSuitPattern.RAINBOW) suitSuffix = ':rb';
+      else if (sPattern === OmahaSuitPattern.THREE_ONE) suitSuffix = ':31';
+      else if (sPattern === OmahaSuitPattern.TWO_ONE_ONE) suitSuffix = ':211';
+      else {
+         // DOUBLE_SUITED (X, X, Y, Y)
+         // Need to identify which ranks pair up!
+         // ABCD. Pairs could be: (0,1)+(2,3) [adj], (0,2)+(1,3) [alt], (0,3)+(1,2) [cross]
+         if (s(0) === s(1) && s(2) === s(3)) suitSuffix = ':ds12';
+         else if (s(0) === s(2) && s(1) === s(3)) suitSuffix = ':ds13';
+         else if (s(0) === s(3) && s(1) === s(2)) suitSuffix = ':ds14';
+      }
+      break;
+  }
+
+  return rankStr + suitSuffix;
+};
+
+/**
+ * Generates a readable description for the hand.
+ */
+export const omahaDescription = (key: string): string => {
+  return "Omaha Hand: " + key;
+};

--- a/poker-sym/src/hands/omaha.ts
+++ b/poker-sym/src/hands/omaha.ts
@@ -1,0 +1,39 @@
+import { HandGroup } from './types.js';
+import { omahaKey, omahaDescription } from './omaha-canonical.js';
+
+/**
+ * Generates all C(52, 4) possible Omaha hands,
+ * maps each to its canonical representation,
+ * and retains only one unique combination per canonical key.
+ */
+export const enumerateOmahaStartingHands = (): HandGroup[] => {
+  const canonicalMap = new Map<string, number[]>();
+
+  // Iterate over all combinations of 4 cards (0 to 51)
+  for (let c1 = 0; c1 < 49; c1++) {
+    for (let c2 = c1 + 1; c2 < 50; c2++) {
+      for (let c3 = c2 + 1; c3 < 51; c3++) {
+        for (let c4 = c3 + 1; c4 < 52; c4++) {
+          const cards = [c1, c2, c3, c4];
+          const key = omahaKey(cards);
+
+          if (!canonicalMap.has(key)) {
+            canonicalMap.set(key, cards);
+          }
+        }
+      }
+    }
+  }
+
+  // Convert the map to an array of HandGroup objects
+  const hands: HandGroup[] = [];
+  for (const [key, cards] of canonicalMap.entries()) {
+    hands.push({
+      key,
+      cards,
+      description: omahaDescription(key),
+    });
+  }
+
+  return hands;
+};

--- a/poker-sym/src/hands/types.ts
+++ b/poker-sym/src/hands/types.ts
@@ -23,3 +23,20 @@ export enum HoldemHandType {
   SUITED = 'suited',
   OFFSUIT = 'offsuit',
 }
+/** Classification of a 4-card Omaha hand's suit pattern. */
+export enum OmahaSuitPattern {
+  MONOSUIT = 'monosuit',       // all 4 cards same suit
+  DOUBLE_SUITED = 'ds',        // two cards of each of 2 suits
+  THREE_ONE = 'three-one',     // 3 cards of one suit, 1 of another
+  TWO_ONE_ONE = 'two-one-one', // 2 cards of one suit, 1 each of 2 others
+  RAINBOW = 'rainbow',         // all 4 different suits
+}
+
+/** Classification of a 4-card Omaha hand's rank pattern. */
+export enum OmahaRankPattern {
+  QUADS = 'quads',       // AAAA
+  TRIPS = 'trips',       // AAAB
+  TWO_PAIR = 'two-pair', // AABB
+  ONE_PAIR = 'one-pair', // AABC
+  HIGH = 'high',         // ABCD (all different)
+}

--- a/poker-sym/src/ranking/omaha-ranker.ts
+++ b/poker-sym/src/ranking/omaha-ranker.ts
@@ -1,0 +1,43 @@
+import { HandStrengthResult, SimulationConfig, SimulationResult } from '../simulation/types.js';
+import { simulateOmahaHand, OmahaEvaluator } from '../simulation/omaha-montecarlo.js';
+import { enumerateOmahaStartingHands } from '../hands/omaha.js';
+import { ProgressCallback } from './ranker.js';
+
+/**
+ * Run a full ranking simulation for Omaha Hi starting hands.
+ *
+ * Simulates all canonical starting hands using Monte Carlo method,
+ * ranks them by strength, and returns the complete result.
+ */
+export const rankOmahaStartingHands = (
+  evaluator: OmahaEvaluator,
+  config: SimulationConfig,
+  onProgress?: ProgressCallback,
+): SimulationResult => {
+  const hands = enumerateOmahaStartingHands();
+  const results: HandStrengthResult[] = [];
+
+  for (let i = 0; i < hands.length; i++) {
+    const hand = hands[i]!;
+    const result = simulateOmahaHand(hand, config, evaluator);
+    results.push(result);
+
+    if (onProgress) {
+      onProgress(i + 1, hands.length, hand.key);
+    }
+  }
+
+  // Sort by winPct (descending) if opponents > 0, otherwise by averageRank (descending)
+  if (config.opponents > 0) {
+    results.sort((a, b) => b.winPct - a.winPct || b.averageRank - a.averageRank);
+  } else {
+    results.sort((a, b) => b.averageRank - a.averageRank);
+  }
+
+  return {
+    gameType: 'omaha-hi',
+    config,
+    hands: results,
+    timestamp: new Date().toISOString(),
+  };
+};

--- a/poker-sym/src/simulation/omaha-montecarlo.ts
+++ b/poker-sym/src/simulation/omaha-montecarlo.ts
@@ -1,0 +1,169 @@
+import { SeedableRNG } from '../utils/rng.js';
+import { makeDeck } from '../utils/deck.js';
+import { HandStrengthResult, SimulationConfig } from './types.js';
+import { HandGroup } from '../hands/types.js';
+
+export type OmahaEvaluator = {
+  eval5: (c1: number, c2: number, c3: number, c4: number, c5: number) => number;
+};
+
+// Choose 2 from 4 hole cards
+function combinations2of4(cards: number[]): number[][] {
+  const result: number[][] = [];
+  for (let i = 0; i < 4; i++) {
+    for (let j = i + 1; j < 4; j++) {
+      result.push([cards[i]!, cards[j]!]);
+    }
+  }
+  return result; // 6 combinations
+}
+
+// Choose 3 from 5 board cards
+function combinations3of5(cards: number[]): number[][] {
+  const result: number[][] = [];
+  for (let i = 0; i < 5; i++) {
+    for (let j = i + 1; j < 5; j++) {
+      for (let k = j + 1; k < 5; k++) {
+        result.push([cards[i]!, cards[j]!, cards[k]!]);
+      }
+    }
+  }
+  return result; // 10 combinations
+}
+
+// Best Omaha hand = max over all 60 combinations of eval5(hole2 + board3)
+function bestOmahaHand(holeCards: number[], board: number[], eval5: OmahaEvaluator['eval5']): number {
+  let best = -Infinity;
+  const holeCombos = combinations2of4(holeCards);
+  const boardCombos = combinations3of5(board);
+
+  for (const hc of holeCombos) {
+    for (const bc of boardCombos) {
+      const score = eval5(hc[0]!, hc[1]!, bc[0]!, bc[1]!, bc[2]!);
+      if (score > best) best = score;
+    }
+  }
+  return best;
+}
+
+/**
+ * Simulate a single raw strength run (no opponents).
+ * Deals 5 community cards and finds the best 5-card combination.
+ */
+const simulateSingleRun = (
+  holeCards: number[],
+  deck: number[],
+  rng: SeedableRNG,
+  evaluator: OmahaEvaluator,
+): number => {
+  // Shuffle remaining deck
+  const d = [...deck];
+  for (let i = d.length - 1; i > 0; i--) {
+    const j = rng.nextInt(i + 1);
+    [d[i], d[j]] = [d[j]!, d[i]!];
+  }
+
+  // Deal 5 community cards
+  const board = d.slice(0, 5);
+
+  // Evaluate the best Omaha hand
+  return bestOmahaHand(holeCards, board, evaluator.eval5);
+};
+
+/**
+ * Simulate a hand with opponents.
+ * Deals opponent hands (4 cards each) and community cards (5 cards),
+ * evaluates all hands, and determines if our hand wins.
+ */
+const simulateWithOpponents = (
+  holeCards: number[],
+  deck: number[],
+  rng: SeedableRNG,
+  evaluator: OmahaEvaluator,
+  numOpponents: number,
+): { win: number; rank: number } => {
+  // Shuffle remaining deck
+  const d = [...deck];
+  for (let i = d.length - 1; i > 0; i--) {
+    const j = rng.nextInt(i + 1);
+    [d[i], d[j]] = [d[j]!, d[i]!];
+  }
+
+  // Deal opponent hands (4 cards each) then 5 community cards
+  const totalNeeded = numOpponents * 4 + 5;
+  const dealt = d.slice(0, totalNeeded);
+
+  // Extract opponent hands
+  const opponentHands: number[][] = [];
+  for (let i = 0; i < numOpponents; i++) {
+    opponentHands.push([dealt[i * 4]!, dealt[i * 4 + 1]!, dealt[i * 4 + 2]!, dealt[i * 4 + 3]!]);
+  }
+
+  // Community cards start after opponent hands
+  const board = dealt.slice(numOpponents * 4, numOpponents * 4 + 5);
+
+  // Evaluate our hand
+  const ourRank = bestOmahaHand(holeCards, board, evaluator.eval5);
+
+  // Evaluate opponent hands
+  let bestOpponentRank = -1;
+  for (const opp of opponentHands) {
+    const oppRank = bestOmahaHand(opp, board, evaluator.eval5);
+    if (oppRank > bestOpponentRank) {
+      bestOpponentRank = oppRank;
+    }
+  }
+
+  // Higher rank = better hand in this library
+  if (ourRank > bestOpponentRank) return { win: 1, rank: ourRank };
+  if (ourRank === bestOpponentRank) return { win: 0.5, rank: ourRank };
+  return { win: 0, rank: ourRank };
+};
+
+/**
+ * Simulate a single Omaha hand.
+ */
+export const simulateOmahaHand = (
+  hand: HandGroup,
+  config: SimulationConfig,
+  evaluator: OmahaEvaluator,
+): HandStrengthResult => {
+  const rng = new SeedableRNG(config.seed ?? Date.now());
+  const deck = makeDeck(hand.cards);
+  const numOpponents = config.opponents;
+
+  if (numOpponents <= 0) {
+    // Raw strength: just average the hand ranks
+    let totalRank = 0;
+    for (let i = 0; i < config.runs; i++) {
+      totalRank += simulateSingleRun(hand.cards, deck, rng, evaluator);
+    }
+    return {
+      key: hand.key,
+      averageRank: totalRank / config.runs,
+      winPct: 0,
+      tiePct: 0,
+      runs: config.runs,
+    };
+  }
+
+  // Equity simulation with opponents
+  let wins = 0;
+  let ties = 0;
+  let totalRank = 0;
+
+  for (let i = 0; i < config.runs; i++) {
+    const result = simulateWithOpponents(hand.cards, deck, rng, evaluator, numOpponents);
+    totalRank += result.rank;
+    if (result.win === 1) wins++;
+    else if (result.win === 0.5) ties++;
+  }
+
+  return {
+    key: hand.key,
+    averageRank: totalRank / config.runs,
+    winPct: (wins / config.runs) * 100,
+    tiePct: (ties / config.runs) * 100,
+    runs: config.runs,
+  };
+};

--- a/poker-sym/test/omaha-canonical.test.ts
+++ b/poker-sym/test/omaha-canonical.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { omahaKey, omahaRankPattern, omahaSuitPattern } from '../src/hands/omaha-canonical.js';
+import { cardIndex } from '../src/utils/deck.js';
+import { OmahaRankPattern, OmahaSuitPattern } from '../src/hands/types.js';
+
+describe('omahaRankPattern', () => {
+  it('identifies quads pattern', () => {
+    const cards = [cardIndex(12,0), cardIndex(12,1), cardIndex(12,2), cardIndex(12,3)];
+    expect(omahaRankPattern(cards)).toBe(OmahaRankPattern.QUADS);
+  });
+
+  it('identifies trips pattern', () => {
+    const cards = [cardIndex(12,0), cardIndex(12,1), cardIndex(12,2), cardIndex(11,0)];
+    expect(omahaRankPattern(cards)).toBe(OmahaRankPattern.TRIPS);
+  });
+
+  it('identifies two-pair pattern', () => {
+    const cards = [cardIndex(12,0), cardIndex(12,1), cardIndex(11,0), cardIndex(11,1)];
+    expect(omahaRankPattern(cards)).toBe(OmahaRankPattern.TWO_PAIR);
+  });
+
+  it('identifies one-pair pattern', () => {
+    const cards = [cardIndex(12,0), cardIndex(12,1), cardIndex(11,0), cardIndex(10,0)];
+    expect(omahaRankPattern(cards)).toBe(OmahaRankPattern.ONE_PAIR);
+  });
+
+  it('identifies high-card pattern', () => {
+    const cards = [cardIndex(12,0), cardIndex(11,1), cardIndex(10,2), cardIndex(9,3)];
+    expect(omahaRankPattern(cards)).toBe(OmahaRankPattern.HIGH);
+  });
+});
+
+describe('omahaSuitPattern', () => {
+  it('identifies monosuit', () => {
+    const cards = [cardIndex(12,0), cardIndex(11,0), cardIndex(10,0), cardIndex(9,0)];
+    expect(omahaSuitPattern(cards)).toBe(OmahaSuitPattern.MONOSUIT);
+  });
+
+  it('identifies double-suited', () => {
+    const cards = [cardIndex(12,0), cardIndex(11,0), cardIndex(10,1), cardIndex(9,1)];
+    expect(omahaSuitPattern(cards)).toBe(OmahaSuitPattern.DOUBLE_SUITED);
+  });
+
+  it('identifies three-one', () => {
+    const cards = [cardIndex(12,0), cardIndex(11,0), cardIndex(10,0), cardIndex(9,1)];
+    expect(omahaSuitPattern(cards)).toBe(OmahaSuitPattern.THREE_ONE);
+  });
+
+  it('identifies two-one-one', () => {
+    const cards = [cardIndex(12,0), cardIndex(11,0), cardIndex(10,1), cardIndex(9,2)];
+    expect(omahaSuitPattern(cards)).toBe(OmahaSuitPattern.TWO_ONE_ONE);
+  });
+
+  it('identifies rainbow', () => {
+    const cards = [cardIndex(12,0), cardIndex(11,1), cardIndex(10,2), cardIndex(9,3)];
+    expect(omahaSuitPattern(cards)).toBe(OmahaSuitPattern.RAINBOW);
+  });
+});
+
+describe('omahaKey', () => {
+  it('produces unique keys for non-isomorphic hands', () => {
+    const hand1 = [cardIndex(12,0), cardIndex(12,1), cardIndex(11,0), cardIndex(11,1)];
+    const hand2 = [cardIndex(12,0), cardIndex(12,1), cardIndex(11,0), cardIndex(11,2)];
+    expect(omahaKey(hand1)).not.toEqual(omahaKey(hand2));
+  });
+
+  it('produces same key for isomorphic hands', () => {
+    const hand1 = [cardIndex(12,0), cardIndex(12,1), cardIndex(11,0), cardIndex(11,1)];
+    const hand2 = [cardIndex(12,2), cardIndex(12,3), cardIndex(11,2), cardIndex(11,3)];
+    expect(omahaKey(hand1)).toEqual(omahaKey(hand2));
+  });
+});

--- a/poker-sym/test/omaha-hands.test.ts
+++ b/poker-sym/test/omaha-hands.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { enumerateOmahaStartingHands } from '../src/hands/omaha.js';
+
+describe('enumerateOmahaStartingHands', () => {
+  it('returns a non-empty array', () => {
+    const hands = enumerateOmahaStartingHands();
+    expect(hands.length).toBeGreaterThan(0);
+  });
+
+  it('each hand has 4 cards', () => {
+    const hands = enumerateOmahaStartingHands();
+    for (const hand of hands) {
+      expect(hand.cards).toHaveLength(4);
+    }
+  });
+
+  it('each hand has a unique key', () => {
+    const hands = enumerateOmahaStartingHands();
+    const keys = new Set(hands.map(h => h.key));
+    expect(keys.size).toBe(hands.length);
+  });
+
+  it('produces canonical representative cards (valid indices 0-51)', () => {
+    const hands = enumerateOmahaStartingHands();
+    for (const hand of hands) {
+      for (const card of hand.cards) {
+        expect(card).toBeGreaterThanOrEqual(0);
+        expect(card).toBeLessThan(52);
+      }
+    }
+  });
+
+  it('has expected approximate count of canonical groups', () => {
+    const hands = enumerateOmahaStartingHands();
+    // Should be somewhere in the range of 3,000-6,000+ groups
+    expect(hands.length).toBeGreaterThan(1000);
+    expect(hands.length).toBeLessThan(10000);
+  });
+});

--- a/poker-sym/test/omaha-ranker.test.ts
+++ b/poker-sym/test/omaha-ranker.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { rankOmahaStartingHands } from '../src/ranking/omaha-ranker.js';
+
+import { cardRank } from '../src/utils/deck.js';
+const mockEval5 = (c1: number, c2: number, c3: number, c4: number, c5: number) => {
+  return cardRank(c1) + cardRank(c2) + cardRank(c3) + cardRank(c4) + cardRank(c5);
+};
+
+describe('rankOmahaStartingHands', () => {
+  it('returns a SimulationResult with gameType omaha-hi', () => {
+    // Only run on a very small subset so test is fast
+    // Let's use a config with small runs and no opponents
+    const result = rankOmahaStartingHands(
+      { eval5: mockEval5 },
+      { runs: 5, opponents: 0, seed: 42, useCache: false },
+    );
+
+    expect(result.gameType).toBe('omaha-hi');
+    expect(result.hands.length).toBeGreaterThan(0);
+    expect(result.timestamp).toBeTruthy();
+  });
+
+  it('sorts hands by winPct descending', () => {
+    const result = rankOmahaStartingHands(
+      { eval5: mockEval5 },
+      { runs: 5, opponents: 1, seed: 42, useCache: false },
+    );
+
+    for (let i = 1; i < result.hands.length; i++) {
+      expect(result.hands[i-1]!.winPct).toBeGreaterThanOrEqual(result.hands[i]!.winPct);
+    }
+  });
+});

--- a/poker-sym/test/omaha-simulation.test.ts
+++ b/poker-sym/test/omaha-simulation.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { simulateOmahaHand } from '../src/simulation/omaha-montecarlo.js';
+import { HandGroup } from '../src/hands/types.js';
+import { cardIndex } from '../src/utils/deck.js';
+
+// Mock eval5 for unit testing without the full evaluator
+// Use a realistic evaluator logic based purely on rank:
+import { cardRank } from '../src/utils/deck.js';
+const mockEval5 = (c1: number, c2: number, c3: number, c4: number, c5: number) => {
+  return cardRank(c1) + cardRank(c2) + cardRank(c3) + cardRank(c4) + cardRank(c5);
+};
+
+describe('simulateOmahaHand', () => {
+  it('returns a HandStrengthResult with correct fields', () => {
+    const hand: HandGroup = {
+      key: 'AAKQ:ds',
+      cards: [cardIndex(12,0), cardIndex(12,1), cardIndex(11,0), cardIndex(10,1)],
+      description: 'Pair of Aces with KQ double-suited',
+    };
+
+    const result = simulateOmahaHand(
+      hand,
+      { runs: 100, opponents: 1, seed: 42, useCache: false },
+      { eval5: mockEval5 },
+    );
+
+    expect(result).toHaveProperty('key', 'AAKQ:ds');
+    expect(result.averageRank).toBeGreaterThan(0);
+    expect(result.runs).toBe(100);
+    expect(result.winPct).toBeGreaterThanOrEqual(0);
+    expect(result.winPct).toBeLessThanOrEqual(100);
+  });
+
+  it('AAxx double-suited wins more than 22xx rainbow against 1 opponent (mock test)', () => {
+    const strongHand: HandGroup = {
+      key: 'AAKK:ds',
+      cards: [cardIndex(12,0), cardIndex(12,1), cardIndex(11,0), cardIndex(11,1)],
+      description: 'Double-suited AAKK',
+    };
+    const weakHand: HandGroup = {
+      key: '2234:rb',
+      cards: [cardIndex(0,0), cardIndex(0,1), cardIndex(1,2), cardIndex(2,3)],
+      description: 'Rainbow 2234',
+    };
+
+    const config = { runs: 100, opponents: 1, seed: 12345, useCache: false };
+    const eval5 = { eval5: mockEval5 };
+
+    const strongResult = simulateOmahaHand(strongHand, config, eval5);
+    const weakResult = simulateOmahaHand(weakHand, config, eval5);
+
+    expect(strongResult.winPct).toBeGreaterThan(weakResult.winPct);
+  });
+});

--- a/poker-sym/tsconfig.json
+++ b/poker-sym/tsconfig.json
@@ -12,13 +12,13 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "..",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
     },
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "../src/**/*.ts"],
   "exclude": ["node_modules", "dist", "test"]
 }


### PR DESCRIPTION
This adds Omaha Hi support to `poker-sym`. It generates canonical keys, iterates combinations properly, and ranks the results using a 60-combo monte-carlo loop.

---
*PR created automatically by Jules for task [7627305358482948342](https://jules.google.com/task/7627305358482948342) started by @MikBin*