### PR TITLE
feat(poker-sym): add Omaha Hi preflop simulation dashboard

### DIFF
--- a/poker-sym/dashboard/omaha.html
+++ b/poker-sym/dashboard/omaha.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>poker-sym — Starting Hand Ranking</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      padding: 2rem;
+    }
+    h1 { text-align: center; font-size: 1.5rem; margin-bottom: 0.25rem; color: #f1f5f9; }
+    .subtitle { text-align: center; color: #94a3b8; font-size: 0.85rem; margin-bottom: 1.5rem; }
+
+    .nav { text-align: center; margin-bottom: 1.5rem; }
+    .nav a { color: #3b82f6; font-size: 0.85rem; text-decoration: none; }
+    .nav a:hover { text-decoration: underline; }
+
+    .controls {
+      max-width: 600px;
+      margin: 0 auto 1.5rem;
+      display: flex;
+      gap: 1rem;
+      align-items: end;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .field { display: flex; flex-direction: column; gap: 0.25rem; }
+    .field label { font-size: 0.75rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.05em; }
+    .field input {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 0.5rem 0.75rem;
+      color: #f1f5f9;
+      font-size: 1rem;
+      width: 120px;
+    }
+    .field input:focus { outline: none; border-color: #3b82f6; }
+
+    button#run {
+      background: #3b82f6;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      padding: 0.55rem 1.5rem;
+      font-size: 1rem;
+      cursor: pointer;
+      font-weight: 600;
+      transition: background 0.2s;
+    }
+    button#run:hover { background: #2563eb; }
+    button#run:disabled { background: #475569; cursor: not-allowed; }
+
+    .progress-container {
+      max-width: 600px;
+      margin: 0 auto 1rem;
+      display: none;
+    }
+    .progress-container.active { display: block; }
+    .progress-bar-bg {
+      background: #1e293b;
+      border-radius: 999px;
+      height: 8px;
+      overflow: hidden;
+    }
+    .progress-bar-fill {
+      background: #3b82f6;
+      height: 100%;
+      width: 0%;
+      transition: width 0.15s;
+      border-radius: 999px;
+    }
+    .progress-text {
+      text-align: center;
+      font-size: 0.8rem;
+      color: #94a3b8;
+      margin-top: 0.25rem;
+    }
+
+    .results-container {
+      max-width: 800px;
+      margin: 0 auto;
+      overflow-x: auto;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.85rem;
+    }
+    th {
+      background: #1e293b;
+      padding: 0.6rem 0.75rem;
+      text-align: left;
+      font-weight: 600;
+      color: #94a3b8;
+      text-transform: uppercase;
+      font-size: 0.7rem;
+      letter-spacing: 0.05em;
+      position: sticky;
+      top: 0;
+    }
+    td { padding: 0.45rem 0.75rem; border-bottom: 1px solid #1e293b; }
+    tr:hover td { background: #1e293b44; }
+    .hand-cell { font-weight: 700; font-family: 'Courier New', monospace; font-size: 0.95rem; }
+
+    .tier-1 { border-left: 3px solid #22c55e; }
+    .tier-2 { border-left: 3px solid #84cc16; }
+    .tier-3 { border-left: 3px solid #eab308; }
+    .tier-4 { border-left: 3px solid #f97316; }
+    .tier-5 { border-left: 3px solid #ef4444; }
+    .tier-6 { border-left: 3px solid #7f1d1d; }
+
+    .tier-badge {
+      display: inline-block;
+      padding: 0.1rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      font-weight: 600;
+    }
+    .tier-badge-1 { background: #22c55e33; color: #22c55e; }
+    .tier-badge-2 { background: #84cc1633; color: #84cc16; }
+    .tier-badge-3 { background: #eab30833; color: #eab308; }
+    .tier-badge-4 { background: #f9731633; color: #f97316; }
+    .tier-badge-5 { background: #ef444433; color: #ef4444; }
+    .tier-badge-6 { background: #7f1d1d55; color: #fca5a5; }
+
+    .init-status {
+      text-align: center;
+      font-size: 0.8rem;
+      color: #94a3b8;
+      margin-bottom: 0.5rem;
+    }
+    .init-status.ready { color: #22c55e; }
+  </style>
+</head>
+<body>
+  <h1>♠ poker-sym ♥</h1>
+  <p class="subtitle">Monte Carlo Starting Hand Ranking — Omaha Hi</p>
+
+  <div class="nav"><a href="index.html">← Back to Texas Hold'em Dashboard</a></div>
+
+  <div id="initStatus" class="init-status">Initializing evaluator...</div>
+
+  <div class="controls">
+    <div class="field">
+      <label for="runs">Runs / Hand</label>
+      <input type="number" id="runs" value="10000" min="100" max="100000" step="1000" />
+    </div>
+    <div class="field">
+      <label for="opponents">Opponents</label>
+      <input type="number" id="opponents" value="1" min="0" max="9" step="1" />
+    </div>
+    <button id="run" disabled>Run Simulation</button>
+  </div>
+
+  <div id="progressContainer" class="progress-container">
+    <div class="progress-bar-bg">
+      <div id="progressFill" class="progress-bar-fill"></div>
+    </div>
+    <div id="progressText" class="progress-text"></div>
+  </div>
+
+  <div id="results" class="results-container"></div>
+
+  <script type="module" src="/src/omaha-main.ts"></script>
+</body>
+</html>

--- a/poker-sym/dashboard/src/omaha-main.ts
+++ b/poker-sym/dashboard/src/omaha-main.ts
@@ -1,0 +1,134 @@
+import { fastHashesCreators } from '../../../src/pokerHashes7.js';
+import { enumerateOmahaStartingHands } from '@poker-sym/hands/omaha.js';
+import { simulateOmahaHand, OmahaEvaluator } from '@poker-sym/simulation/omaha-montecarlo.js';
+import { SimulationConfig, SimulationResult } from '@poker-sym/simulation/types.js';
+import { TIERS, assignTiers } from '@poker-sym/ranking/tiers.js';
+import { handOfFiveEvalIndexed } from '../../../src/pokerEvaluator5.js';
+
+// DOM elements
+const initStatus = document.getElementById('initStatus')!;
+const runsInput = document.getElementById('runs') as HTMLInputElement;
+const opponentsInput = document.getElementById('opponents') as HTMLInputElement;
+const runBtn = document.getElementById('run') as HTMLButtonElement;
+const progressContainer = document.getElementById('progressContainer')!;
+const progressFill = document.getElementById('progressFill')!;
+const progressText = document.getElementById('progressText')!;
+const resultsDiv = document.getElementById('results')!;
+
+// Initialize hash tables
+async function init() {
+  await new Promise((r) => setTimeout(r, 50));
+  fastHashesCreators.high();
+  initStatus.textContent = '✓ Evaluator ready';
+  initStatus.classList.add('ready');
+  runBtn.disabled = false;
+}
+
+// Run simulation in chunks to keep UI responsive
+function runSimulation(config: SimulationConfig): Promise<SimulationResult> {
+  return new Promise((resolve) => {
+    const evaluator: OmahaEvaluator = { eval5: handOfFiveEvalIndexed };
+
+    const hands = enumerateOmahaStartingHands();
+    const results: SimulationResult['hands'] = [];
+    let i = 0;
+    const chunkSize = 15;
+
+    function processChunk() {
+      const end = Math.min(i + chunkSize, hands.length);
+      for (; i < end; i++) {
+        const hand = hands[i]!;
+        const result = simulateOmahaHand(hand, config, evaluator);
+        results.push(result);
+      }
+
+      const pct = (i / hands.length) * 100;
+      progressFill.style.width = pct + '%';
+      progressText.textContent = i + '/' + hands.length + ' hands (' + pct.toFixed(0) + '%)';
+
+      if (i < hands.length) {
+        setTimeout(processChunk, 0);
+      } else {
+        if (config.opponents > 0) {
+          results.sort((a, b) => b.winPct - a.winPct || b.averageRank - a.averageRank);
+        } else {
+          results.sort((a, b) => b.averageRank - a.averageRank);
+        }
+        resolve({
+          gameType: 'omaha-hi',
+          config,
+          hands: results,
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }
+
+    processChunk();
+  });
+}
+
+// Render results table
+function renderResults(result: SimulationResult) {
+  const { hands, config } = result;
+  const hasOpponents = config.opponents > 0;
+  const tiered = assignTiers(hands);
+
+  let html = '<table><thead><tr>';
+  html += '<th>#</th><th>Hand</th><th>Tier</th>';
+  if (hasOpponents) {
+    html += '<th>Win%</th><th>Tie%</th>';
+  }
+  html += '<th>Avg Rank</th></tr></thead><tbody>';
+
+  for (const h of tiered) {
+    const tierNum = h.tier + 1;
+    const tierName = TIERS[h.tier]!.name;
+
+    html += '<tr class="tier-' + tierNum + '">';
+    html += '<td>' + h.rank + '</td>';
+    html += '<td class="hand-cell">' + h.key + '</td>';
+    html += '<td><span class="tier-badge tier-badge-' + tierNum + '">' + tierName + '</span></td>';
+    if (hasOpponents) {
+      html += '<td>' + h.winPct.toFixed(2) + '%</td>';
+      html += '<td>' + h.tiePct.toFixed(2) + '%</td>';
+    }
+    html += '<td>' + h.averageRank.toFixed(1) + '</td>';
+    html += '</tr>';
+  }
+
+  html += '</tbody></table>';
+  resultsDiv.innerHTML = html;
+}
+
+// Event handler
+runBtn.addEventListener('click', async () => {
+  const runs = parseInt(runsInput.value, 10) || 10000;
+  const opponents = parseInt(opponentsInput.value, 10) || 0;
+
+  const config: SimulationConfig = {
+    runs: Math.max(100, Math.min(100000, runs)),
+    opponents: Math.max(0, Math.min(9, opponents)),
+    useCache: true,
+  };
+
+  runBtn.disabled = true;
+  runBtn.textContent = 'Running...';
+  progressContainer.classList.add('active');
+  progressFill.style.width = '0%';
+  progressText.textContent = 'Starting...';
+  resultsDiv.innerHTML = '';
+
+  const startTime = performance.now();
+  const result = await runSimulation(config);
+  const elapsed = ((performance.now() - startTime) / 1000).toFixed(1);
+
+  progressFill.style.width = '100%';
+  progressText.textContent = '✓ Completed in ' + elapsed + 's';
+
+  renderResults(result);
+
+  runBtn.disabled = false;
+  runBtn.textContent = 'Run Simulation';
+});
+
+init();


### PR DESCRIPTION
# Add Omaha Dashboard for poker-sym

This PR introduces a standalone web dashboard for Monte Carlo simulation of Omaha Hi starting hands.

## Changes
- **New `omaha.html`:** Mirrors the `index.html` structure exactly, featuring the same dark theme UI, controls (runs, opponents), chunked progress bar, and tier-styled data tables. It includes a navigation link back to the Texas Hold'em dashboard.
- **New `src/omaha-main.ts`:** Implements the underlying evaluation logic.
  - Resolves aliases to properly import `@poker-sym/hands/omaha.js` and `@poker-sym/simulation/omaha-montecarlo.js`.
  - Initializes hash tables asynchronously just like Hold'em, providing the browser time to display loading states.
  - Employs a chunk size of `15` to preserve UI responsiveness during heavy calculations (~60 per hand combination) across Omaha's 9,854 canonical hands.
  - Applies identical table sorting and tiering mechanisms.

No modifications were made to the existing Texas Hold'em dashboard code. All styles match precisely. Validated via local browser verification.

---
*PR created automatically by Jules for task [12550019330748623127](https://jules.google.com/task/12550019330748623127) started by @MikBin*