### PR TITLE
feat: Add Razz variant to poker-sym CLI

### DIFF
--- a/fix_unused.ts
+++ b/fix_unused.ts
@@ -1,0 +1,5 @@
+import fs from 'fs';
+
+let content = fs.readFileSync('poker-sym/src/simulation/razz-montecarlo.ts', 'utf8');
+content = content.replace(/      let isWin = true;\n      let isTie = false;\n/g, '');
+fs.writeFileSync('poker-sym/src/simulation/razz-montecarlo.ts', content);

--- a/poker-sym/src/cli.ts
+++ b/poker-sym/src/cli.ts
@@ -9,6 +9,8 @@ import { handOfFiveEvalIndexed } from '../../src/pokerEvaluator5.js';
 import { fastHashesCreators } from '../../src/pokerHashes7.js';
 import { rankHoldemStartingHands } from './ranking/ranker.js';
 import { rankOmahaStartingHands } from './ranking/omaha-ranker.js';
+import { rankRazzStartingHands } from './ranking/razz-ranker.js';
+
 import { rankStreets } from './ranking/street-ranker.js';
 import { SimulationConfig, SimulationResult, HandStrengthResult } from './simulation/types.js';
 import { formatTable, formatJSON, formatCSV, formatMarkdown } from './output.js';
@@ -26,7 +28,7 @@ program
   .name('poker-sym')
   .description('Monte Carlo simulation for poker starting hand ranking (Hold\'em, Omaha)')
   .version('0.1.0')
-  .option('-g, --game <type>', 'game variant: holdem, omaha', 'holdem')
+  .option('-g, --game <type>', 'game variant: holdem, omaha, razz', 'holdem')
   .option('-n, --runs <number>', 'number of simulation runs per hand', '10000')
   .option('-o, --opponents <number>', 'number of opponents (0 = raw strength)', '0')
   .option('-s, --seed <number>', 'random seed for reproducibility')
@@ -91,6 +93,51 @@ program
           }
         });
       }
+
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      process.stderr.write(`\n  Completed in ${elapsed}s\n`);
+
+      let output: string;
+      switch (format) {
+        case 'json':
+          output = formatJSON(result);
+          break;
+        case 'csv':
+          output = formatCSV(result);
+          break;
+        case 'md':
+          output = formatMarkdown(result);
+          break;
+        default:
+          output = formatTable(result);
+      }
+
+      if (outputFile) {
+        fs.writeFileSync(outputFile, output, 'utf-8');
+        console.error(`\nResults written to ${outputFile}`);
+      } else {
+        console.log(output);
+      }
+    } else if (game === 'razz') {
+      if (streetMode) {
+        console.error('Street analysis for Razz is not yet supported.');
+        process.exit(1);
+      }
+
+      console.error(
+        `Running Razz preflop simulation...\n` +
+          `  Hands: 455 | Runs/hand: ${config.runs} | Opponents: ${config.opponents}`
+      );
+
+      // Initialize low hash tables for Razz
+      fastHashesCreators.Ato5();
+
+      const result = rankRazzStartingHands(config, (completed, total, hand) => {
+        if (completed % 10 === 0 || completed === total) {
+          const pct = ((completed / total) * 100).toFixed(0);
+          process.stderr.write(`\r  Progress: ${completed}/${total} (${pct}%) — ${hand}    `);
+        }
+      });
 
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
       process.stderr.write(`\n  Completed in ${elapsed}s\n`);

--- a/poker-sym/src/hands/stud.ts
+++ b/poker-sym/src/hands/stud.ts
@@ -1,0 +1,54 @@
+import { cardIndex } from '../utils/deck.js';
+import { HandGroup } from './types.js';
+
+const RANK_SYMBOLS = ['2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K', 'A'] as const;
+
+export const rankSym = (r: number): string => RANK_SYMBOLS[r]!;
+
+/**
+ * Enumerate all 455 canonical 3-card starting hands for Stud/Razz.
+ *
+ * For A-5 Razz, suits are entirely irrelevant, and flushes do not count.
+ * A starting hand is uniquely identified by the combination of 3 card ranks (with replacement).
+ * C(13 + 3 - 1, 3) = C(15, 3) = 455 possible canonical hands.
+ */
+export const enumerateStudStartingHands = (): HandGroup[] => {
+  const hands: HandGroup[] = [];
+
+  // Iterate all combinations of 3 ranks with replacement
+  for (let r1 = 12; r1 >= 0; r1--) {
+    for (let r2 = r1; r2 >= 0; r2--) {
+      for (let r3 = r2; r3 >= 0; r3--) {
+        // r1 >= r2 >= r3 is guaranteed by the loop structure
+        const key = `${rankSym(r1)}${rankSym(r2)}${rankSym(r3)}`;
+
+        // Determine suits: if ranks are identical, use different suits to form valid cards.
+        let s1 = 0, s2 = 0, s3 = 0;
+
+        if (r1 === r2 && r2 === r3) {
+          s1 = 0; s2 = 1; s3 = 2; // e.g. AAA -> As, Ad, Ah
+        } else if (r1 === r2) {
+          s1 = 0; s2 = 1; s3 = 0; // e.g. AAK -> As, Ad, Ks
+        } else if (r2 === r3) {
+          s1 = 0; s2 = 0; s3 = 1; // e.g. AKK -> As, Ks, Kd
+        } else {
+          s1 = 0; s2 = 0; s3 = 0; // e.g. AKQ -> As, Ks, Qs
+        }
+
+        const cards = [
+          cardIndex(r1, s1),
+          cardIndex(r2, s2),
+          cardIndex(r3, s3)
+        ];
+
+        hands.push({
+          key,
+          cards,
+          description: `Stud Hand ${key}`
+        });
+      }
+    }
+  }
+
+  return hands;
+};

--- a/poker-sym/src/ranking/razz-ranker.ts
+++ b/poker-sym/src/ranking/razz-ranker.ts
@@ -1,0 +1,50 @@
+import { SimulationConfig, SimulationResult, HandStrengthResult } from '../simulation/types.js';
+import { enumerateStudStartingHands } from '../hands/stud.js';
+import { simulateRazzHand } from '../simulation/razz-montecarlo.js';
+
+/**
+ * Ranks all 455 Razz starting hands.
+ *
+ * @param config Simulation configuration
+ * @param onProgress Callback for reporting progress to CLI
+ * @returns Ranked simulation results
+ */
+export const rankRazzStartingHands = (
+  config: SimulationConfig,
+  onProgress?: (completed: number, total: number, hand: string) => void,
+): SimulationResult => {
+  const hands = enumerateStudStartingHands();
+  const total = hands.length;
+  const results: HandStrengthResult[] = [];
+
+  for (let i = 0; i < total; i++) {
+    const handGroup = hands[i]!;
+
+    // In sequential execution, vary the seed slightly per hand so they don't share identical rng state
+    const handConfig = {
+      ...config,
+      seed: config.seed !== undefined ? config.seed + i : undefined,
+    };
+
+    const result = simulateRazzHand(handGroup.key, handGroup.cards, handConfig);
+    results.push(result);
+
+    if (onProgress) {
+      onProgress(i + 1, total, handGroup.key);
+    }
+  }
+
+  // Sort primarily by win percentage, then by average rank
+  if (config.opponents > 0) {
+    results.sort((a, b) => b.winPct - a.winPct || b.averageRank - a.averageRank);
+  } else {
+    results.sort((a, b) => b.averageRank - a.averageRank);
+  }
+
+  return {
+    gameType: 'razz',
+    config,
+    hands: results,
+    timestamp: new Date().toISOString(),
+  };
+};

--- a/poker-sym/src/simulation/razz-montecarlo.ts
+++ b/poker-sym/src/simulation/razz-montecarlo.ts
@@ -1,0 +1,75 @@
+import { makeDeck, drawCopy } from '../utils/deck.js';
+import { SeedableRNG } from '../utils/rng.js';
+import { SimulationConfig, HandStrengthResult } from './types.js';
+import { LowAto5Evaluator } from '../../../src/core/LowEvaluator.js';
+
+// Pre-instantiate evaluator
+const evaluator = new LowAto5Evaluator();
+
+/**
+ * Run a Monte Carlo simulation for a specific Razz starting hand.
+ *
+ * @param key Canonical hand key (e.g. 'A32')
+ * @param heroCards The 3 representative cards for this hand
+ * @param config Simulation configuration
+ * @returns Simulation results including win/tie percentages
+ */
+export const simulateRazzHand = (
+  key: string,
+  heroCards: number[],
+  config: SimulationConfig,
+): HandStrengthResult => {
+  const rng = config.seed !== undefined ? new SeedableRNG(config.seed) : Math.random;
+  const deck = makeDeck(heroCards);
+  const runs = config.runs;
+  const opponents = config.opponents;
+  const rawMode = opponents === 0;
+
+  let totalRank = 0;
+  let wins = 0;
+  let ties = 0;
+
+  for (let r = 0; r < runs; r++) {
+    // Razz: Hero has 3 cards, gets 4 more.
+    // Opponents get 7 random cards.
+    // Total cards drawn = 4 + (7 * opponents)
+    const cardsToDraw = 4 + 7 * opponents;
+    const board = drawCopy(deck, cardsToDraw, rng);
+
+    // Hero's full 7 cards
+    const heroFull = [...heroCards, ...board.slice(0, 4)];
+
+    // Evaluate hero (higher return value means better A-5 low hand)
+    const heroScore = evaluator.evaluate(heroFull);
+    totalRank += heroScore;
+
+    if (!rawMode) {
+      let bestOpponentScore = -1;
+
+      // Evaluate opponents
+      for (let o = 0; o < opponents; o++) {
+        const oppStartIdx = 4 + o * 7;
+        const oppCards = board.slice(oppStartIdx, oppStartIdx + 7);
+        const oppScore = evaluator.evaluate(oppCards);
+
+        if (oppScore > bestOpponentScore) {
+          bestOpponentScore = oppScore;
+        }
+      }
+
+      if (heroScore > bestOpponentScore) {
+        wins++;
+      } else if (heroScore === bestOpponentScore) {
+        ties++;
+      }
+    }
+  }
+
+  return {
+    key,
+    averageRank: totalRank / runs,
+    winPct: rawMode ? 0 : (wins / runs) * 100,
+    tiePct: rawMode ? 0 : (ties / runs) * 100,
+    runs,
+  };
+};

--- a/poker-sym/test/hands/stud.test.ts
+++ b/poker-sym/test/hands/stud.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { enumerateStudStartingHands } from '../../src/hands/stud.js';
+
+describe('Stud/Razz Starting Hands', () => {
+  it('generates exactly 455 canonical 3-card hands', () => {
+    const hands = enumerateStudStartingHands();
+    expect(hands.length).toBe(455);
+  });
+
+  it('generates unique canonical keys', () => {
+    const hands = enumerateStudStartingHands();
+    const keys = new Set(hands.map(h => h.key));
+    expect(keys.size).toBe(455);
+  });
+
+  it('includes specific expected hands', () => {
+    const hands = enumerateStudStartingHands();
+
+    // A23 (best razz hand)
+    const a23 = hands.find(h => h.key === 'A32');
+    expect(a23).toBeDefined();
+    expect(a23?.cards).toHaveLength(3);
+
+    // KKK (worst razz hand, sort of)
+    const kkk = hands.find(h => h.key === 'KKK');
+    expect(kkk).toBeDefined();
+    expect(kkk?.cards).toHaveLength(3);
+  });
+});

--- a/poker-sym/test/ranking/razz-ranker.test.ts
+++ b/poker-sym/test/ranking/razz-ranker.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { rankRazzStartingHands } from '../../src/ranking/razz-ranker.js';
+import { DEFAULT_CONFIG } from '../../src/simulation/types.js';
+import { fastHashesCreators } from '../../../src/pokerHashes7.js';
+
+describe('Razz Ranker', () => {
+  beforeAll(() => {
+    fastHashesCreators.Ato5();
+  });
+
+  it('ranks Razz starting hands correctly', () => {
+    // Small run count for testing
+    const config = { ...DEFAULT_CONFIG, runs: 10, opponents: 1, seed: 123 };
+
+    // We'll pass a dummy callback for progress
+    const onProgress = () => {};
+
+    const result = rankRazzStartingHands(config, onProgress);
+
+    expect(result.gameType).toBe('razz');
+    expect(result.config).toEqual(config);
+    expect(result.hands.length).toBe(455);
+
+    // Check that results are sorted by winPct descending
+    for (let i = 0; i < result.hands.length - 1; i++) {
+      const current = result.hands[i];
+      const next = result.hands[i+1];
+      if (current && next) {
+        expect(current.winPct).toBeGreaterThanOrEqual(next.winPct);
+      }
+    }
+  });
+});

--- a/poker-sym/test/simulation/razz-montecarlo.test.ts
+++ b/poker-sym/test/simulation/razz-montecarlo.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { simulateRazzHand } from '../../src/simulation/razz-montecarlo.js';
+import { cardIndex } from '../../src/utils/deck.js';
+import { DEFAULT_CONFIG } from '../../src/simulation/types.js';
+import { fastHashesCreators } from '../../../src/pokerHashes7.js';
+
+describe('Razz Monte Carlo Simulation', () => {
+  beforeAll(() => {
+    // We need the low hashes for LowAto5Evaluator
+    fastHashesCreators.Ato5();
+  });
+
+  it('correctly simulates A23 (best hand) and finds high win rate', () => {
+    const config = { ...DEFAULT_CONFIG, runs: 100, opponents: 1, seed: 42 };
+
+    // A23 -> indices: 12, 0, 1 (using suit 0)
+    const cards = [cardIndex(12, 0), cardIndex(0, 0), cardIndex(1, 0)];
+
+    const result = simulateRazzHand('A32', cards, config);
+
+    expect(result.key).toBe('A32');
+    expect(result.runs).toBe(100);
+    expect(result.winPct).toBeGreaterThan(50); // A23 is very strong
+  });
+
+  it('correctly simulates KKK (worst hand) and finds low win rate', () => {
+    const config = { ...DEFAULT_CONFIG, runs: 100, opponents: 1, seed: 42 };
+
+    // KKK -> indices: 11 (suits 0, 1, 2)
+    const cards = [cardIndex(11, 0), cardIndex(11, 1), cardIndex(11, 2)];
+
+    const result = simulateRazzHand('KKK', cards, config);
+
+    expect(result.key).toBe('KKK');
+    expect(result.runs).toBe(100);
+    expect(result.winPct).toBeLessThan(50); // KKK is terrible
+  });
+});


### PR DESCRIPTION
This PR introduces the Razz (7-Card Stud A-5 Lowball) game variant to the `poker-sym` Monte Carlo simulation tool.

**Key Features:**
1. **Starting Hand Enumerator (`src/hands/stud.ts`)**: Accurately computes the 455 canonical 3-card starting hands, properly omitting suit considerations since flushes don't penalize in A-5.
2. **Simulation Engine (`src/simulation/razz-montecarlo.ts`)**: Runs Monte Carlo evaluation drawing 4 additional cards for the hero and 7 random cards for opponents, leveraging the existing `LowAto5Evaluator`.
3. **Ranking Service (`src/ranking/razz-ranker.ts`)**: Orchestrates the ranking across all 455 Razz starting hands.
4. **CLI Integration (`src/cli.ts`)**: Plugs the Razz variant into the command-line options (`-g razz`) matching Hold'em output styles and properly invoking the lowball hash initialization `fastHashesCreators.Ato5()`.
5. **Testing**: Includes fully passing unit tests.

---
*PR created automatically by Jules for task [15166743670765979857](https://jules.google.com/task/15166743670765979857) started by @MikBin*