### PR TITLE
feat(poker-sym): add 7-Card Stud simulation

### DIFF
--- a/poker-sym/src/cli.ts
+++ b/poker-sym/src/cli.ts
@@ -9,6 +9,7 @@ import { handOfFiveEvalIndexed } from '../../src/pokerEvaluator5.js';
 import { fastHashesCreators } from '../../src/pokerHashes7.js';
 import { rankHoldemStartingHands } from './ranking/ranker.js';
 import { rankOmahaStartingHands } from './ranking/omaha-ranker.js';
+import { rankStudStartingHands } from './ranking/stud-ranker.js';
 import { rankStreets } from './ranking/street-ranker.js';
 import { SimulationConfig, SimulationResult, HandStrengthResult } from './simulation/types.js';
 import { formatTable, formatJSON, formatCSV, formatMarkdown } from './output.js';
@@ -24,9 +25,9 @@ const program = new Command();
 
 program
   .name('poker-sym')
-  .description('Monte Carlo simulation for poker starting hand ranking (Hold\'em, Omaha)')
+  .description('Monte Carlo simulation for poker starting hand ranking (Hold\'em, Omaha, 7-Card Stud)')
   .version('0.1.0')
-  .option('-g, --game <type>', 'game variant: holdem, omaha', 'holdem')
+  .option('-g, --game <type>', 'game variant: holdem, omaha, stud, 7card-stud', 'holdem')
   .option('-n, --runs <number>', 'number of simulation runs per hand', '10000')
   .option('-o, --opponents <number>', 'number of opponents (0 = raw strength)', '0')
   .option('-s, --seed <number>', 'random seed for reproducibility')
@@ -91,6 +92,52 @@ program
           }
         });
       }
+
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      process.stderr.write(`\n  Completed in ${elapsed}s\n`);
+
+      let output: string;
+      switch (format) {
+        case 'json':
+          output = formatJSON(result);
+          break;
+        case 'csv':
+          output = formatCSV(result);
+          break;
+        case 'md':
+          output = formatMarkdown(result);
+          break;
+        default:
+          output = formatTable(result);
+      }
+
+      if (outputFile) {
+        fs.writeFileSync(outputFile, output, 'utf-8');
+        console.error(`\nResults written to ${outputFile}`);
+      } else {
+        console.log(output);
+      }
+    } else if (game === 'stud' || game === '7card-stud') {
+      if (config.opponents > 6) {
+        console.error('Error: 7-Card Stud supports a maximum of 6 opponents (52 cards total, 7 cards per player + 3 hole cards).');
+        process.exit(1);
+      }
+      if (streetMode) {
+        console.error('Street analysis for 7-Card Stud is not yet supported.');
+        process.exit(1);
+      }
+
+      console.error(
+        `Running 7-Card Stud starting hand simulation...\n` +
+          `  Hands: 1,755 | Runs/hand: ${config.runs} | Opponents: ${config.opponents}`
+      );
+
+      const result = rankStudStartingHands(evalFn7, config, (completed, total, hand) => {
+        if (completed % 10 === 0 || completed === total) {
+          const pct = ((completed / total) * 100).toFixed(0);
+          process.stderr.write(`\r  Progress: ${completed}/${total} (${pct}%) — ${hand}    `);
+        }
+      });
 
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
       process.stderr.write(`\n  Completed in ${elapsed}s\n`);

--- a/poker-sym/src/hands/stud.ts
+++ b/poker-sym/src/hands/stud.ts
@@ -1,0 +1,86 @@
+import { cardIndex } from '../utils/deck.js';
+import { HandGroup } from './types.js';
+
+export const enumerateStudStartingHands = (): HandGroup[] => {
+  const hands: HandGroup[] = [];
+
+  const rankSym = (r: number) => '23456789TJQKA'[r];
+
+  // 1. Trips
+  for (let r = 12; r >= 0; r--) {
+    hands.push({
+      key: `${rankSym(r)}${rankSym(r)}${rankSym(r)}`,
+      cards: [cardIndex(r, 0), cardIndex(r, 1), cardIndex(r, 2)],
+      description: `Rolled up ${rankSym(r)}s`,
+    });
+  }
+
+  // 2. Pairs
+  for (let r1 = 12; r1 >= 0; r1--) {
+    for (let r2 = 12; r2 >= 0; r2--) {
+      if (r1 === r2) continue;
+
+      const str = r1 > r2 ? `${rankSym(r1)}${rankSym(r1)}${rankSym(r2)}` : `${rankSym(r2)}${rankSym(r1)}${rankSym(r1)}`;
+
+      // Pair 2-suited: odd card shares suit with one of the pair cards
+      hands.push({
+        key: `${str} 2-suited`,
+        cards: [cardIndex(r1, 0), cardIndex(r1, 1), cardIndex(r2, 0)],
+        description: `Pair of ${rankSym(r1)}s with ${rankSym(r2)} kicker (2-suited)`,
+      });
+
+      // Pair rainbow: all different suits
+      hands.push({
+        key: `${str} rainbow`,
+        cards: [cardIndex(r1, 0), cardIndex(r1, 1), cardIndex(r2, 2)],
+        description: `Pair of ${rankSym(r1)}s with ${rankSym(r2)} kicker (rainbow)`,
+      });
+    }
+  }
+
+  // 3. Three different ranks
+  for (let r1 = 12; r1 >= 2; r1--) {
+    for (let r2 = r1 - 1; r2 >= 1; r2--) {
+      for (let r3 = r2 - 1; r3 >= 0; r3--) {
+        const str = `${rankSym(r1)}${rankSym(r2)}${rankSym(r3)}`;
+
+        // Suited: all suit 0
+        hands.push({
+          key: `${str} suited`,
+          cards: [cardIndex(r1, 0), cardIndex(r2, 0), cardIndex(r3, 0)],
+          description: `${str} suited`,
+        });
+
+        // 2-suited (high): r1 and r2 share suit 0, r3 is suit 1
+        hands.push({
+          key: `${str} 2-suited (high)`,
+          cards: [cardIndex(r1, 0), cardIndex(r2, 0), cardIndex(r3, 1)],
+          description: `${str} 2-suited (high)`,
+        });
+
+        // 2-suited (gap): r1 and r3 share suit 0, r2 is suit 1
+        hands.push({
+          key: `${str} 2-suited (gap)`,
+          cards: [cardIndex(r1, 0), cardIndex(r2, 1), cardIndex(r3, 0)],
+          description: `${str} 2-suited (gap)`,
+        });
+
+        // 2-suited (low): r2 and r3 share suit 0, r1 is suit 1
+        hands.push({
+          key: `${str} 2-suited (low)`,
+          cards: [cardIndex(r1, 1), cardIndex(r2, 0), cardIndex(r3, 0)],
+          description: `${str} 2-suited (low)`,
+        });
+
+        // Rainbow: suits 0, 1, 2
+        hands.push({
+          key: `${str} rainbow`,
+          cards: [cardIndex(r1, 0), cardIndex(r2, 1), cardIndex(r3, 2)],
+          description: `${str} rainbow`,
+        });
+      }
+    }
+  }
+
+  return hands;
+};

--- a/poker-sym/src/output.ts
+++ b/poker-sym/src/output.ts
@@ -28,7 +28,8 @@ export const formatTable = (result: SimulationResult): string => {
     table.push(row as string[]);
   }
 
-  let output = `\nTexas Hold'em Starting Hand Ranking\n`;
+  const gameName = result.gameType === 'omaha-hi' ? 'Omaha Hi' : result.gameType === '7card-stud' ? '7-Card Stud' : 'Texas Hold\'em';
+  let output = `\n${gameName} Starting Hand Ranking\n`;
   output += `Runs: ${result.config.runs} | Opponents: ${result.config.opponents} | Date: ${result.timestamp}\n`;
   output += table.toString();
   return output;
@@ -81,7 +82,8 @@ export const formatMarkdown = (result: SimulationResult): string => {
   const tiered = assignTiers(result.hands);
   const hasOpponents = result.config.opponents > 0;
 
-  let md = `# Texas Hold'em Starting Hand Ranking\n\n`;
+  const gameName = result.gameType === 'omaha-hi' ? 'Omaha Hi' : result.gameType === '7card-stud' ? '7-Card Stud' : 'Texas Hold\'em';
+  let md = `# ${gameName} Starting Hand Ranking\n\n`;
   md += `- **Runs:** ${result.config.runs}\n`;
   md += `- **Opponents:** ${result.config.opponents}\n`;
   md += `- **Date:** ${result.timestamp}\n\n`;

--- a/poker-sym/src/ranking/stud-ranker.ts
+++ b/poker-sym/src/ranking/stud-ranker.ts
@@ -1,0 +1,36 @@
+import { HandStrengthResult, SimulationConfig, SimulationResult } from '../simulation/types.js';
+import { simulateStudHand, StudEvaluator } from '../simulation/stud-montecarlo.js';
+import { enumerateStudStartingHands } from '../hands/stud.js';
+import { ProgressCallback } from './ranker.js';
+
+export const rankStudStartingHands = (
+  evaluator: StudEvaluator,
+  config: SimulationConfig,
+  onProgress?: ProgressCallback,
+): SimulationResult => {
+  const hands = enumerateStudStartingHands();
+  const results: HandStrengthResult[] = [];
+
+  for (let i = 0; i < hands.length; i++) {
+    const hand = hands[i]!;
+    const result = simulateStudHand(hand, config, evaluator);
+    results.push(result);
+
+    if (onProgress) {
+      onProgress(i + 1, hands.length, hand.key);
+    }
+  }
+
+  if (config.opponents > 0) {
+    results.sort((a, b) => b.winPct - a.winPct || b.averageRank - a.averageRank);
+  } else {
+    results.sort((a, b) => b.averageRank - a.averageRank);
+  }
+
+  return {
+    gameType: '7card-stud',
+    config,
+    hands: results,
+    timestamp: new Date().toISOString(),
+  };
+};

--- a/poker-sym/src/simulation/stud-montecarlo.ts
+++ b/poker-sym/src/simulation/stud-montecarlo.ts
@@ -1,0 +1,126 @@
+import { SeedableRNG } from '../utils/rng.js';
+import { makeDeck } from '../utils/deck.js';
+import { HandGroup } from '../hands/types.js';
+import { HandStrengthResult, SimulationConfig } from './types.js';
+
+export type StudEvaluator = (c1: number, c2: number, c3: number, c4: number, c5: number, c6: number, c7: number) => number;
+
+const simulateSingleRun = (
+  holeCards: number[],
+  deck: number[],
+  rng: SeedableRNG,
+  evaluator: StudEvaluator,
+): number => {
+  const d = [...deck];
+  for (let i = d.length - 1; i > 0; i--) {
+    const j = rng.nextInt(i + 1);
+    [d[i], d[j]] = [d[j]!, d[i]!];
+  }
+
+  // Draw 4 more cards to make a 7-card hand
+  const board = d.slice(0, 4);
+
+  return evaluator(
+    holeCards[0]!,
+    holeCards[1]!,
+    holeCards[2]!,
+    board[0]!,
+    board[1]!,
+    board[2]!,
+    board[3]!,
+  );
+};
+
+const simulateWithOpponents = (
+  holeCards: number[],
+  deck: number[],
+  rng: SeedableRNG,
+  evaluator: StudEvaluator,
+  numOpponents: number,
+): { win: number; rank: number } => {
+  const d = [...deck];
+  for (let i = d.length - 1; i > 0; i--) {
+    const j = rng.nextInt(i + 1);
+    [d[i], d[j]] = [d[j]!, d[i]!];
+  }
+
+  // Draw 4 more cards for the hero
+  const heroBoard = d.slice(0, 4);
+  const ourRank = evaluator(
+    holeCards[0]!,
+    holeCards[1]!,
+    holeCards[2]!,
+    heroBoard[0]!,
+    heroBoard[1]!,
+    heroBoard[2]!,
+    heroBoard[3]!,
+  );
+
+  let bestOpponentRank = -1;
+  let offset = 4;
+
+  // Draw 7 cards for each opponent
+  for (let i = 0; i < numOpponents; i++) {
+    const oppRank = evaluator(
+      d[offset]!,
+      d[offset + 1]!,
+      d[offset + 2]!,
+      d[offset + 3]!,
+      d[offset + 4]!,
+      d[offset + 5]!,
+      d[offset + 6]!,
+    );
+    if (oppRank > bestOpponentRank) {
+      bestOpponentRank = oppRank;
+    }
+    offset += 7;
+  }
+
+  if (ourRank > bestOpponentRank) return { win: 1, rank: ourRank };
+  if (ourRank === bestOpponentRank) return { win: 0.5, rank: ourRank };
+  return { win: 0, rank: ourRank };
+};
+
+export const simulateStudHand = (
+  hand: HandGroup,
+  config: SimulationConfig,
+  evaluator: StudEvaluator,
+): HandStrengthResult => {
+  const rng = new SeedableRNG(config.seed ?? Date.now());
+  const deck = makeDeck(hand.cards);
+  const numOpponents = config.opponents;
+  if (numOpponents > 6) throw new Error('Maximum of 6 opponents allowed for 7-Card Stud');
+
+  if (numOpponents <= 0) {
+    let totalRank = 0;
+    for (let i = 0; i < config.runs; i++) {
+      totalRank += simulateSingleRun(hand.cards, deck, rng, evaluator);
+    }
+    return {
+      key: hand.key,
+      averageRank: totalRank / config.runs,
+      winPct: 0,
+      tiePct: 0,
+      runs: config.runs,
+    };
+  }
+
+  let wins = 0;
+  let ties = 0;
+  let totalRank = 0;
+
+  for (let i = 0; i < config.runs; i++) {
+    const result = simulateWithOpponents(hand.cards, deck, rng, evaluator, numOpponents);
+    totalRank += result.rank;
+    if (result.win === 1) wins++;
+    else if (result.win === 0.5) ties++;
+  }
+
+  return {
+    key: hand.key,
+    averageRank: totalRank / config.runs,
+    winPct: (wins / config.runs) * 100,
+    tiePct: (ties / config.runs) * 100,
+    runs: config.runs,
+  };
+};

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { formatTable, formatMarkdown } from '../poker-sym/src/output.js';
+import { SimulationResult } from '../poker-sym/src/simulation/types.js';
+
+describe('Output Formatter', () => {
+  it('should format table with 7-Card Stud label', () => {
+    const result: SimulationResult = {
+      gameType: '7card-stud',
+      config: { runs: 10, opponents: 0, useCache: false },
+      hands: [
+        { key: 'AAA', averageRank: 100, winPct: 0, tiePct: 0, runs: 10 }
+      ],
+      timestamp: '2023-01-01',
+    };
+    const output = formatTable(result);
+    expect(output).toContain('7-Card Stud Starting Hand Ranking');
+  });
+
+  it('should format markdown with 7-Card Stud label', () => {
+    const result: SimulationResult = {
+      gameType: '7card-stud',
+      config: { runs: 10, opponents: 0, useCache: false },
+      hands: [
+        { key: 'AAA', averageRank: 100, winPct: 0, tiePct: 0, runs: 10 }
+      ],
+      timestamp: '2023-01-01',
+    };
+    const output = formatMarkdown(result);
+    expect(output).toContain('# 7-Card Stud Starting Hand Ranking');
+  });
+});

--- a/test/stud-montecarlo.test.ts
+++ b/test/stud-montecarlo.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { simulateStudHand } from '../poker-sym/src/simulation/stud-montecarlo.js';
+import { HandGroup } from '../poker-sym/src/hands/types.js';
+
+describe('Stud Monte Carlo Simulation Engine', () => {
+  const dummyEvaluator = vi.fn().mockReturnValue(100);
+
+  const dummyHand: HandGroup = {
+    key: 'AAA',
+    cards: [0, 1, 2],
+    description: 'Rolled up As',
+  };
+
+  it('should calculate raw strength when opponents = 0', () => {
+    const config = { runs: 10, opponents: 0, useCache: false, seed: 123 };
+    const result = simulateStudHand(dummyHand, config, dummyEvaluator);
+
+    expect(dummyEvaluator).toHaveBeenCalledTimes(10);
+    expect(result.averageRank).toBe(100);
+    expect(result.winPct).toBe(0);
+    expect(result.tiePct).toBe(0);
+  });
+
+  it('should run equity simulation when opponents > 0', () => {
+    const config = { runs: 5, opponents: 2, useCache: false, seed: 123 };
+
+    let callCount = 0;
+    const customEval = vi.fn().mockImplementation(() => {
+      callCount++;
+      const sequence = [
+        10, 5, 2,   // R1: Win (1)
+        10, 10, 5,  // R2: Tie (1)
+        5, 10, 2,   // R3: Loss (1)
+        10, 2, 2,   // R4: Win (2)
+        10, 10, 10, // R5: Tie (2)
+      ];
+      return sequence[callCount - 1];
+    });
+
+    const result = simulateStudHand(dummyHand, config, customEval);
+
+    expect(customEval).toHaveBeenCalledTimes(15);
+    expect(result.averageRank).toBe(9);
+    expect(result.winPct).toBe(40);
+    expect(result.tiePct).toBe(40);
+  });
+
+  it('should throw error when opponents > 6', () => {
+    const config = { runs: 10, opponents: 7, useCache: false, seed: 123 };
+    expect(() => simulateStudHand(dummyHand, config, dummyEvaluator)).toThrow('Maximum of 6 opponents allowed');
+  });
+});

--- a/test/stud-ranker.test.ts
+++ b/test/stud-ranker.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { rankStudStartingHands } from '../poker-sym/src/ranking/stud-ranker.js';
+
+describe('Stud Ranker', () => {
+  it('should simulate all 1755 hands and sort them', () => {
+    let callCount = 0;
+    const dummyEvaluator = vi.fn().mockImplementation(() => {
+       callCount++;
+       return Math.random() * 100;
+    });
+
+    const config = { runs: 2, opponents: 0, useCache: false };
+    const result = rankStudStartingHands(dummyEvaluator, config);
+
+    expect(result.gameType).toBe('7card-stud');
+    expect(result.hands.length).toBe(1755);
+    expect(callCount).toBe(3510);
+
+    for (let i = 1; i < result.hands.length; i++) {
+      expect(result.hands[i - 1]!.averageRank).toBeGreaterThanOrEqual(result.hands[i]!.averageRank);
+    }
+  });
+});

--- a/test/stud.test.ts
+++ b/test/stud.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { enumerateStudStartingHands } from '../poker-sym/src/hands/stud.js';
+
+describe('Stud Hand Enumeration', () => {
+  it('should generate exactly 1755 canonical starting hands', () => {
+    const hands = enumerateStudStartingHands();
+    expect(hands.length).toBe(1755);
+  });
+
+  it('should have unique keys for all hands', () => {
+    const hands = enumerateStudStartingHands();
+    const keys = new Set(hands.map(h => h.key));
+    expect(keys.size).toBe(1755);
+  });
+
+  it('should correctly format trips', () => {
+    const hands = enumerateStudStartingHands();
+    const aces = hands.find(h => h.key === 'AAA');
+    expect(aces).toBeDefined();
+    expect(aces!.cards.length).toBe(3);
+    expect(aces!.description).toBe('Rolled up As');
+  });
+
+  it('should correctly format pairs', () => {
+    const hands = enumerateStudStartingHands();
+
+    const pairHighRainbow = hands.find(h => h.key === 'AAK rainbow');
+    expect(pairHighRainbow).toBeDefined();
+    expect(pairHighRainbow!.description).toBe('Pair of As with K kicker (rainbow)');
+
+    const pairLow2Suited = hands.find(h => h.key === 'K22 2-suited');
+    expect(pairLow2Suited).toBeDefined();
+    expect(pairLow2Suited!.description).toBe('Pair of 2s with K kicker (2-suited)');
+  });
+
+  it('should correctly format 3 different ranks', () => {
+    const hands = enumerateStudStartingHands();
+
+    const suited = hands.find(h => h.key === 'AKQ suited');
+    expect(suited).toBeDefined();
+
+    const rainbow = hands.find(h => h.key === '753 rainbow');
+    expect(rainbow).toBeDefined();
+
+    const highSuited = hands.find(h => h.key === 'JT9 2-suited (high)');
+    expect(highSuited).toBeDefined();
+
+    const gapSuited = hands.find(h => h.key === 'JT9 2-suited (gap)');
+    expect(gapSuited).toBeDefined();
+
+    const lowSuited = hands.find(h => h.key === 'JT9 2-suited (low)');
+    expect(lowSuited).toBeDefined();
+  });
+});


### PR DESCRIPTION
Adds support for evaluating and ranking 7-Card Stud starting hands using Monte Carlo simulation. Following the pattern of Texas Hold'em and Omaha, the simulation engine calculates preflop equities by drawing board/opponent cards from the remaining deck.

---
*PR created automatically by Jules for task [16626550373101819195](https://jules.google.com/task/16626550373101819195) started by @MikBin*