### PR TITLE
Fix Lo Avg Rank column sorting

### DIFF
--- a/poker-sym/dashboard/src/sortable-table.ts
+++ b/poker-sym/dashboard/src/sortable-table.ts
@@ -32,8 +32,8 @@ export function makeSortable(table: HTMLTableElement): void {
       rows.sort((a, b) => {
         const aCell = a.querySelectorAll('td')[colIndex] as HTMLTableCellElement | undefined;
         const bCell = b.querySelectorAll('td')[colIndex] as HTMLTableCellElement | undefined;
-        const aVal = aCell ? parseFloat(aCell.dataset.value ?? '0') : 0;
-        const bVal = bCell ? parseFloat(bCell.dataset.value ?? '0') : 0;
+        const aVal = aCell ? parseFloat(aCell.dataset.value ?? '') : NaN;
+        const bVal = bCell ? parseFloat(bCell.dataset.value ?? '') : NaN;
 
         // NaN values (e.g. "—" cells with no data-value) always sort to the bottom
         const aNaN = isNaN(aVal);


### PR DESCRIPTION
Fixes bug where sorting the 'Lo Avg Rank' column incorrectly handled '—' empty values. Changed fallback from '0' to '' to produce NaN.

---
*PR created automatically by Jules for task [6469891498048908734](https://jules.google.com/task/6469891498048908734) started by @MikBin*