### PR TITLE
feat: Omaha Hi Street-by-Street Analysis

### DIFF
--- a/poker-sym/dashboard/src/street-omaha-main.ts
+++ b/poker-sym/dashboard/src/street-omaha-main.ts
@@ -1,0 +1,301 @@
+import { fastHashesCreators } from '../../../src/pokerHashes7.js';
+import { handOfFiveEvalIndexed } from '../../../src/pokerEvaluator5.js';
+import { enumerateOmahaStartingHands } from '../../src/hands/omaha.js';
+import { analyzeOmahaHandStreets, FiveCardEvalFn } from '../../src/simulation/street-analysis.js';
+import { StreetHandResult, StreetAnalysisResult, HAND_CATEGORY_NAMES } from '../../src/simulation/types.js';
+
+// DOM
+const initStatus = document.getElementById('initStatus')!;
+const runsInput = document.getElementById('runs') as HTMLInputElement;
+const seedInput = document.getElementById('seed') as HTMLInputElement;
+const runBtn = document.getElementById('run') as HTMLButtonElement;
+const progressContainer = document.getElementById('progressContainer')!;
+const progressFill = document.getElementById('progressFill')!;
+const progressText = document.getElementById('progressText')!;
+const resultsDiv = document.getElementById('results')!;
+const detailOverlay = document.getElementById('detailOverlay')!;
+const detailContent = document.getElementById('detailContent')!;
+const detailClose = document.getElementById('detailClose')!;
+
+let currentResult: StreetAnalysisResult | null = null;
+
+// Init
+async function init() {
+  await new Promise((r) => setTimeout(r, 50));
+  fastHashesCreators.high();
+  initStatus.textContent = '✓ Evaluator ready';
+  initStatus.classList.add('ready');
+  runBtn.disabled = false;
+}
+
+// Run simulation in chunks
+function runStreetSimulation(runs: number, seed?: number): Promise<StreetAnalysisResult> {
+  return new Promise((resolve) => {
+    const evalFn5: FiveCardEvalFn = handOfFiveEvalIndexed;
+
+    const hands = enumerateOmahaStartingHands();
+    const results: StreetHandResult[] = [];
+    let i = 0;
+    const chunkSize = 2; // smaller chunk size for Omaha since it's more computationally expensive
+
+    function processChunk() {
+      const end = Math.min(i + chunkSize, hands.length);
+      for (; i < end; i++) {
+        const hand = hands[i]!;
+        const handSeed = seed != null ? seed + i : undefined;
+        const result = analyzeOmahaHandStreets(hand, runs, evalFn5, handSeed);
+        results.push(result);
+      }
+
+      const pct = (i / hands.length) * 100;
+      progressFill.style.width = pct + '%';
+      progressText.textContent = i + '/' + hands.length + ' hands (' + pct.toFixed(0) + '%)';
+
+      if (i < hands.length) {
+        setTimeout(processChunk, 0);
+      } else {
+        results.sort((a, b) => b.river.averageRank - a.river.averageRank);
+        resolve({
+          gameType: 'omaha-hi' as any,
+          config: { runs, opponents: 0, seed },
+          hands: results,
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }
+
+    processChunk();
+  });
+}
+
+// Find dominant category
+const dominantCat = (stats: any): { name: string; pct: number } => {
+  let best = 'high card';
+  let bestPct = 0;
+  for (const cat of HAND_CATEGORY_NAMES) {
+    const pct = stats.categories[cat] || 0;
+    if (pct > bestPct) {
+      bestPct = pct;
+      best = cat;
+    }
+  }
+  return { name: best, pct: bestPct };
+};
+
+// Sort state
+let sortKey = 'river-avg';
+let sortDir: 'desc' | 'asc' = 'desc';
+
+/** Extract numeric sort value from a hand result for a given sort key. */
+const sortValue = (h: StreetHandResult, key: string): number => {
+  switch (key) {
+    case 'flop-avg':
+      return h.flop.averageRank;
+    case 'flop-top':
+      return dominantCat(h.flop).pct;
+    case 'flop-hit':
+      return h.flop.realization.playabilityScore;
+    case 'turn-avg':
+      return h.turn.averageRank;
+    case 'turn-top':
+      return dominantCat(h.turn).pct;
+    case 'turn-hit':
+      return h.turn.realization.playabilityScore;
+    case 'river-avg':
+      return h.river.averageRank;
+    case 'river-top':
+      return dominantCat(h.river).pct;
+    case 'river-hit':
+      return h.river.realization.playabilityScore;
+    default:
+      return h.river.averageRank;
+  }
+};
+
+const SORT_ARROW: Record<string, string> = { desc: ' ▼', asc: ' ▲' };
+
+// Render summary table
+function renderSummaryTable(result: StreetAnalysisResult) {
+  // Build sorted index array
+  const indices = result.hands.map((_h, i) => i);
+  indices.sort((a, b) => {
+    const va = sortValue(result.hands[a]!, sortKey);
+    const vb = sortValue(result.hands[b]!, sortKey);
+    return sortDir === 'desc' ? vb - va : va - vb;
+  });
+
+  let html = '<table><thead><tr>';
+  html += '<th>#</th><th>Hand</th>';
+  for (const col of [
+    { key: 'flop-avg', label: 'Flop Avg', sortable: true },
+    { key: 'flop-hit', label: 'Flop Hit%', sortable: false },
+    { key: 'turn-avg', label: 'Turn Avg', sortable: true },
+    { key: 'turn-hit', label: 'Turn Hit%', sortable: false },
+    { key: 'river-avg', label: 'River Avg', sortable: true },
+    { key: 'river-hit', label: 'River Hit%', sortable: false },
+  ]) {
+    if (col.sortable) {
+      const arrow = sortKey === col.key ? SORT_ARROW[sortDir] : '';
+      html += `<th class="sortable" data-sort="${col.key}">${col.label}${arrow}</th>`;
+    } else {
+      html += `<th>${col.label}</th>`;
+    }
+  }
+  html += '</tr></thead><tbody>';
+
+  for (let rank = 0; rank < indices.length; rank++) {
+    const i = indices[rank]!;
+    const h = result.hands[i]!;
+
+    html += `<tr data-idx="${i}">`;
+    html += `<td class="num">${rank + 1}</td>`;
+    html += `<td class="hand-cell">${h.hand}</td>`;
+    html += `<td class="num">${h.flop.averageRank.toFixed(0)}</td>`;
+    html += `<td class="num">${h.flop.realization.playabilityScore.toFixed(0)}%</td>`;
+    html += `<td class="num">${h.turn.averageRank.toFixed(0)}</td>`;
+    html += `<td class="num">${h.turn.realization.playabilityScore.toFixed(0)}%</td>`;
+    html += `<td class="num">${h.river.averageRank.toFixed(0)}</td>`;
+    html += `<td class="num">${h.river.realization.playabilityScore.toFixed(0)}%</td>`;
+    html += '</tr>';
+  }
+
+  html += '</tbody></table>';
+  resultsDiv.innerHTML = html;
+
+  // Add sort handlers on headers
+  resultsDiv.querySelectorAll('th.sortable').forEach((th) => {
+    th.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const key = (th as HTMLElement).dataset.sort!;
+      if (sortKey === key) {
+        sortDir = sortDir === 'desc' ? 'asc' : 'desc';
+      } else {
+        sortKey = key;
+        sortDir = 'desc';
+      }
+      renderSummaryTable(result);
+    });
+  });
+
+  // Add click handlers for detail view
+  resultsDiv.querySelectorAll('tr[data-idx]').forEach((tr) => {
+    tr.addEventListener('click', () => {
+      const idx = parseInt((tr as HTMLElement).dataset.idx!, 10);
+      showDetail(idx);
+    });
+  });
+}
+
+// Render category bars for a street
+const catBarClass = (cat: string): string => `cat-fill-${cat.replace(/ /g, '-')}`;
+
+function renderCategoryBars(stats: any): string {
+  let html = '<div class="cat-bars">';
+  for (const cat of HAND_CATEGORY_NAMES) {
+    const pct = stats.categories[cat] || 0;
+    if (pct > 0.1) {
+      html += `<div class="cat-row">`;
+      html += `<span class="cat-name">${cat}</span>`;
+      html += `<div class="cat-bar-bg"><div class="cat-bar-fill ${catBarClass(cat)}" style="width:${Math.max(pct, 0.5)}%"></div></div>`;
+      html += `<span class="cat-pct">${pct.toFixed(1)}%</span>`;
+      html += '</div>';
+    }
+  }
+  html += '</div>';
+  return html;
+}
+
+// Show detail panel for a specific hand
+function showDetail(idx: number) {
+  if (!currentResult) return;
+  const h = currentResult.hands[idx]!;
+
+  let html = `<div class="detail-hand">${idx + 1}. ${h.hand}</div>`;
+
+  for (const [street, cssClass] of [
+    ['flop', 'flop-title'],
+    ['turn', 'turn-title'],
+    ['river', 'river-title'],
+  ] as const) {
+    const stats = h[street];
+    const dom = dominantCat(stats);
+
+    html += `<div class="street-section">`;
+    html += `<div class="street-title ${cssClass}">${street.toUpperCase()}</div>`;
+
+    html += `<div class="stat-row">`;
+    html += `<span><span class="stat-label">Avg Rank:</span> <span class="stat-value">${stats.averageRank.toFixed(1)}</span></span>`;
+    html += `<span><span class="stat-label">σ:</span> <span class="stat-value">${stats.distribution.stdDev.toFixed(1)}</span></span>`;
+    html += `<span><span class="stat-label">P50:</span> <span class="stat-value">${stats.distribution.percentiles.p50.toFixed(0)}</span></span>`;
+    html += `<span><span class="stat-label">Top:</span> <span class="stat-value">${dom.name} ${dom.pct.toFixed(1)}%</span></span>`;
+    html += `</div>`;
+
+    // Category bars
+    html += renderCategoryBars(stats);
+
+    // Realization chips
+    html += `<div class="realization-row">`;
+    html += `<div class="realization-chip"><span class="label">Improve:</span><span class="value">${stats.realization.improvementRate.toFixed(1)}%</span></div>`;
+    html += `<div class="realization-chip"><span class="label">Nuts:</span><span class="value">${stats.realization.nutPercentage.toFixed(1)}%</span></div>`;
+    html += `<div class="realization-chip"><span class="label">Hit%:</span><span class="value">${stats.realization.playabilityScore.toFixed(1)}%</span></div>`;
+    if (stats.realization.drawConversionRate > 0) {
+      html += `<div class="realization-chip"><span class="label">Draw→:</span><span class="value">${stats.realization.drawConversionRate.toFixed(1)}%</span></div>`;
+    }
+    html += `</div>`;
+
+    // Texture breakdown
+    if (stats.textureEquity.length > 0) {
+      html += `<div class="texture-grid">`;
+      for (const tex of stats.textureEquity) {
+        html += `<div class="texture-card"><span class="texture-name">${tex.texture}</span> <span class="texture-stat">×${tex.count} avg=${tex.averageRank.toFixed(0)}</span></div>`;
+      }
+      html += `</div>`;
+    }
+
+    html += '</div>';
+  }
+
+  detailContent.innerHTML = html;
+  detailOverlay.classList.add('active');
+}
+
+// Close detail
+detailClose.addEventListener('click', () => {
+  detailOverlay.classList.remove('active');
+});
+detailOverlay.addEventListener('click', (e) => {
+  if (e.target === detailOverlay) {
+    detailOverlay.classList.remove('active');
+  }
+});
+
+// Run button
+runBtn.addEventListener('click', async () => {
+  const runs = parseInt(runsInput.value, 10) || 1000; // default to 1000 for Omaha to make it faster
+  const seedVal = seedInput.value ? parseInt(seedInput.value, 10) : undefined;
+
+  runBtn.disabled = true;
+  runBtn.textContent = 'Running...';
+  progressContainer.classList.add('active');
+  progressFill.style.width = '0%';
+  progressText.textContent = 'Starting...';
+  resultsDiv.innerHTML = '';
+
+  const startTime = performance.now();
+  const result = await runStreetSimulation(
+    Math.max(100, Math.min(100000, runs)),
+    seedVal,
+  );
+  const elapsed = ((performance.now() - startTime) / 1000).toFixed(1);
+
+  progressFill.style.width = '100%';
+  progressText.textContent = '✓ Completed in ' + elapsed + 's — Click any hand for details';
+
+  currentResult = result;
+  renderSummaryTable(result);
+
+  runBtn.disabled = false;
+  runBtn.textContent = 'Run Street Analysis';
+});
+
+init();

--- a/poker-sym/dashboard/street-omaha.html
+++ b/poker-sym/dashboard/street-omaha.html
@@ -19,29 +19,237 @@
     .nav a { color: #3b82f6; text-decoration: none; font-size: 0.85rem; }
     .nav a:hover { text-decoration: underline; }
 
-    .coming-soon {
-      max-width: 500px;
-      margin: 4rem auto;
-      text-align: center;
+    .controls {
+      max-width: 700px;
+      margin: 0 auto 1.5rem;
+      display: flex;
+      gap: 1rem;
+      align-items: end;
+      flex-wrap: wrap;
+      justify-content: center;
     }
-    .coming-soon-icon { font-size: 4rem; margin-bottom: 1rem; }
-    .coming-soon h2 { font-size: 1.5rem; color: #f1f5f9; margin-bottom: 0.5rem; }
-    .coming-soon p { color: #94a3b8; line-height: 1.6; font-size: 0.95rem; }
-    .badge {
-      display: inline-block;
-      background: #8b5cf622;
-      color: #8b5cf6;
-      padding: 0.3rem 1rem;
-      border-radius: 999px;
-      font-size: 0.8rem;
+    .field { display: flex; flex-direction: column; gap: 0.25rem; }
+    .field label { font-size: 0.75rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.05em; }
+    .field input {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 0.5rem 0.75rem;
+      color: #f1f5f9;
+      font-size: 1rem;
+      width: 120px;
+    }
+    .field input:focus { outline: none; border-color: #3b82f6; }
+
+    button#run {
+      background: #8b5cf6;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      padding: 0.55rem 1.5rem;
+      font-size: 1rem;
+      cursor: pointer;
       font-weight: 600;
-      margin-top: 1.5rem;
+      transition: background 0.2s;
     }
+    button#run:hover { background: #7c3aed; }
+    button#run:disabled { background: #475569; cursor: not-allowed; }
+
+    .progress-container {
+      max-width: 700px;
+      margin: 0 auto 1rem;
+      display: none;
+    }
+    .progress-container.active { display: block; }
+    .progress-bar-bg {
+      background: #1e293b;
+      border-radius: 999px;
+      height: 8px;
+      overflow: hidden;
+    }
+    .progress-bar-fill {
+      background: #8b5cf6;
+      height: 100%;
+      width: 0%;
+      transition: width 0.15s;
+      border-radius: 999px;
+    }
+    .progress-text {
+      text-align: center;
+      font-size: 0.8rem;
+      color: #94a3b8;
+      margin-top: 0.25rem;
+    }
+
+    .init-status {
+      text-align: center;
+      font-size: 0.8rem;
+      color: #94a3b8;
+      margin-bottom: 0.5rem;
+    }
+    .init-status.ready { color: #22c55e; }
+
+    /* Summary Table */
+    .results-container {
+      max-width: 1100px;
+      margin: 0 auto;
+      overflow-x: auto;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.8rem;
+    }
+    th {
+      background: #1e293b;
+      padding: 0.6rem 0.6rem;
+      text-align: left;
+      font-weight: 600;
+      color: #94a3b8;
+      text-transform: uppercase;
+      font-size: 0.65rem;
+      letter-spacing: 0.05em;
+      position: sticky;
+      top: 0;
+    }
+    th.sortable {
+      cursor: pointer;
+      user-select: none;
+    }
+    th.sortable:hover { color: #e2e8f0; }
+    td { padding: 0.4rem 0.6rem; border-bottom: 1px solid #1e293b; }
+    tr:hover td { background: #1e293b44; }
+    tr.selected td { background: #1e293b88; }
+    .hand-cell { font-weight: 700; font-family: 'Courier New', monospace; font-size: 0.95rem; cursor: pointer; }
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
+
+    /* Detail Panel */
+    .detail-overlay {
+      display: none;
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(0,0,0,0.6);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .detail-overlay.active { display: flex; }
+    .detail-panel {
+      background: #1e293b;
+      border-radius: 12px;
+      padding: 1.5rem 2rem;
+      max-width: 700px;
+      width: 90%;
+      max-height: 85vh;
+      overflow-y: auto;
+      position: relative;
+    }
+    .detail-close {
+      position: absolute;
+      top: 0.75rem;
+      right: 1rem;
+      background: none;
+      border: none;
+      color: #94a3b8;
+      font-size: 1.5rem;
+      cursor: pointer;
+    }
+    .detail-close:hover { color: #f1f5f9; }
+    .detail-hand { font-size: 1.5rem; font-weight: 700; font-family: 'Courier New', monospace; margin-bottom: 1rem; }
+
+    .street-section { margin-bottom: 1.5rem; }
+    .street-title {
+      font-size: 0.85rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 0.5rem;
+      padding-bottom: 0.25rem;
+      border-bottom: 1px solid #334155;
+    }
+    .street-title.flop-title { color: #22c55e; }
+    .street-title.turn-title { color: #eab308; }
+    .street-title.river-title { color: #3b82f6; }
+
+    .stat-row {
+      display: flex;
+      gap: 1.5rem;
+      margin-bottom: 0.25rem;
+      font-size: 0.8rem;
+    }
+    .stat-label { color: #94a3b8; min-width: 80px; }
+    .stat-value { font-weight: 600; font-variant-numeric: tabular-nums; }
+
+    /* Category bars */
+    .cat-bars { margin-top: 0.5rem; }
+    .cat-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.15rem;
+      font-size: 0.75rem;
+    }
+    .cat-name { min-width: 90px; color: #94a3b8; text-align: right; }
+    .cat-bar-bg {
+      flex: 1;
+      background: #0f172a;
+      height: 12px;
+      border-radius: 3px;
+      overflow: hidden;
+    }
+    .cat-bar-fill {
+      height: 100%;
+      border-radius: 3px;
+      transition: width 0.3s;
+    }
+    .cat-pct { min-width: 45px; text-align: right; font-variant-numeric: tabular-nums; }
+
+    .cat-fill-high-card { background: #64748b; }
+    .cat-fill-one-pair { background: #3b82f6; }
+    .cat-fill-two-pair { background: #22c55e; }
+    .cat-fill-three-of-a-kind { background: #84cc16; }
+    .cat-fill-straight { background: #eab308; }
+    .cat-fill-flush { background: #f97316; }
+    .cat-fill-full-house { background: #ef4444; }
+    .cat-fill-four-of-a-kind { background: #ec4899; }
+    .cat-fill-straight-flush { background: #a855f7; }
+
+    /* Equity curve mini-sparkline placeholder */
+    .realization-row {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin-top: 0.5rem;
+    }
+    .realization-chip {
+      background: #0f172a;
+      border-radius: 6px;
+      padding: 0.3rem 0.6rem;
+      font-size: 0.75rem;
+    }
+    .realization-chip .label { color: #94a3b8; }
+    .realization-chip .value { font-weight: 600; margin-left: 0.25rem; }
+
+    /* Texture breakdown */
+    .texture-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+    }
+    .texture-card {
+      background: #0f172a;
+      border-radius: 6px;
+      padding: 0.4rem 0.6rem;
+      font-size: 0.75rem;
+    }
+    .texture-name { color: #94a3b8; }
+    .texture-stat { font-weight: 600; font-variant-numeric: tabular-nums; }
   </style>
 </head>
 <body>
   <h1>♠ poker-sym — Street Analysis ♥</h1>
-  <p class="subtitle">Omaha Hi — Street-by-Street Analysis</p>
+  <p class="subtitle">Flop / Turn / River Evolution — Omaha Hi Starting Hands</p>
   <div class="nav">
     <a href="index.html">🏠 Home</a><span class="sep" style="color:#475569;margin:0 0.3rem">·</span>
     <a href="street.html">Hold'em</a><span class="sep" style="color:#475569;margin:0 0.3rem">·</span>
@@ -52,17 +260,36 @@
     <a href="street-razz.html">Razz</a>
   </div>
 
-  <div class="coming-soon">
-    <div class="coming-soon-icon">🌽</div>
-    <h2>Omaha Hi — Street Analysis</h2>
-    <p>Track how each Omaha Hi starting hand evolves through the Flop, Turn, and River with equity distributions, hand category breakdowns, and board texture analysis.</p>
-    <div class="badge">🚧 Coming Soon</div>
+  <div id="initStatus" class="init-status">Initializing evaluator...</div>
+
+  <div class="controls">
+    <div class="field">
+      <label for="runs">Runs / Hand</label>
+      <input type="number" id="runs" value="1000" min="100" max="100000" step="1000" />
+    </div>
+    <div class="field">
+      <label for="seed">Seed</label>
+      <input type="number" id="seed" value="" min="0" placeholder="random" />
+    </div>
+    <button id="run" disabled>Run Street Analysis</button>
   </div>
+
+  <div id="progressContainer" class="progress-container">
+    <div class="progress-bar-bg">
+      <div id="progressFill" class="progress-bar-fill"></div>
+    </div>
+    <div id="progressText" class="progress-text"></div>
+  </div>
+
+  <div id="results" class="results-container"></div>
+
+  <div id="detailOverlay" class="detail-overlay">
+    <div class="detail-panel">
+      <button class="detail-close" id="detailClose">&times;</button>
+      <div id="detailContent"></div>
+    </div>
+  </div>
+
+  <script type="module" src="/src/street-omaha-main.ts"></script>
 </body>
 </html>
-</task_progress>
-- [x] Create holdem.html (renamed from old index.html with updated nav)
-- [x] Create new dashboard landing page (`index.html`) with two cards
-- [x] Update navigation on all existing pages
-- [ ] Create 5 Coming Soon street analysis placeholder pages (1/5)
-</write_to_file>

--- a/poker-sym/src/simulation/street-analysis.ts
+++ b/poker-sym/src/simulation/street-analysis.ts
@@ -379,3 +379,116 @@ export const analyzeHandStreets = (
     river: buildStreetStats(riverRanks, riverCatIndices, turnTextures, turnCatIndices, null, false),
   };
 };
+
+/**
+ * Evaluate best Omaha hand from 4 hole cards + 3, 4, or 5 board cards.
+ * Must use exactly 2 from hole cards and 3 from board.
+ */
+const bestOmahaOfN = (holeCards: number[], boardCards: number[], eval5: FiveCardEvalFn): number => {
+  let best = -1;
+  // Combinations of 2 from 4 hole cards
+  for (let i = 0; i < 4; i++) {
+    for (let j = i + 1; j < 4; j++) {
+      const h1 = holeCards[i]!;
+      const h2 = holeCards[j]!;
+
+      // Combinations of 3 from N board cards
+      for (let b1 = 0; b1 < boardCards.length; b1++) {
+        for (let b2 = b1 + 1; b2 < boardCards.length; b2++) {
+          for (let b3 = b2 + 1; b3 < boardCards.length; b3++) {
+            const rank = eval5(h1, h2, boardCards[b1]!, boardCards[b2]!, boardCards[b3]!);
+            if (rank > best) best = rank;
+          }
+        }
+      }
+    }
+  }
+  return best;
+};
+
+/**
+ * Run a single Monte Carlo simulation for Omaha street analysis.
+ */
+const simulateSingleOmahaStreetRun = (
+  holeCards: number[],
+  deck: number[],
+  rng: SeedableRNG,
+  eval5: FiveCardEvalFn,
+): RunData => {
+  const d = [...deck];
+  for (let i = d.length - 1; i > 0; i--) {
+    const j = rng.nextInt(i + 1);
+    [d[i], d[j]] = [d[j]!, d[i]!];
+  }
+
+  const board = d.slice(0, 5);
+
+  // --- Flop: 4 hole + 3 board ---
+  const flopBoard = board.slice(0, 3);
+  const flopRank = bestOmahaOfN(holeCards, flopBoard, eval5);
+  const flopTexture = primaryTexture(flopBoard);
+  const flopCatIdx = categoryIndex(flopRank);
+
+  // --- Turn: 4 hole + 4 board ---
+  const turnBoard = board.slice(0, 4);
+  const turnRank = bestOmahaOfN(holeCards, turnBoard, eval5);
+  const turnTexture = primaryTexture(turnBoard);
+  const turnCatIdx = categoryIndex(turnRank);
+
+  // --- River: 4 hole + 5 board ---
+  const riverRank = bestOmahaOfN(holeCards, board, eval5);
+  const riverCatIdx = categoryIndex(riverRank);
+
+  return {
+    flopRank,
+    turnRank,
+    riverRank,
+    flopTexture,
+    turnTexture,
+    flopCategoryIdx: flopCatIdx,
+    turnCategoryIdx: turnCatIdx,
+    riverCategoryIdx: riverCatIdx,
+  };
+};
+
+/**
+ * Run multi-street analysis for a single Omaha starting hand.
+ */
+export const analyzeOmahaHandStreets = (
+  hand: HandGroup,
+  runs: number,
+  eval5: FiveCardEvalFn,
+  seed?: number,
+): StreetHandResult => {
+  const rng = new SeedableRNG(seed ?? Date.now());
+  const deck = makeDeck(hand.cards);
+
+  const flopRanks: number[] = [];
+  const turnRanks: number[] = [];
+  const riverRanks: number[] = [];
+  const flopTextures: BoardTexture[] = [];
+  const turnTextures: BoardTexture[] = [];
+  const flopCatIndices: number[] = [];
+  const turnCatIndices: number[] = [];
+  const riverCatIndices: number[] = [];
+
+  for (let i = 0; i < runs; i++) {
+    const run = simulateSingleOmahaStreetRun(hand.cards, deck, rng, eval5);
+
+    flopRanks.push(run.flopRank);
+    turnRanks.push(run.turnRank);
+    riverRanks.push(run.riverRank);
+    flopTextures.push(run.flopTexture);
+    turnTextures.push(run.turnTexture);
+    flopCatIndices.push(run.flopCategoryIdx);
+    turnCatIndices.push(run.turnCategoryIdx);
+    riverCatIndices.push(run.riverCategoryIdx);
+  }
+
+  return {
+    hand: hand.key,
+    flop: buildStreetStats(flopRanks, flopCatIndices, flopTextures, null, riverCatIndices, true),
+    turn: buildStreetStats(turnRanks, turnCatIndices, turnTextures, flopCatIndices, riverCatIndices, true),
+    river: buildStreetStats(riverRanks, riverCatIndices, turnTextures, turnCatIndices, null, false),
+  };
+};


### PR DESCRIPTION
Implemented the Street-by-Street Analysis page for Omaha Hi poker in the `poker-sym` dashboard.

Adapted the existing Texas Hold'em street-by-street framework (`street.html` and `street-main.ts`) for Omaha rules:
- Added `analyzeOmahaHandStreets` and supporting evaluation logic to compute correct Omaha permutations dynamically for Flop (3 cards), Turn (4 cards), and River (5 cards) combinations.
- Replaced the previous "Coming Soon" stub in `street-omaha.html` with a fully interactive dashboard matching the design standard of the other analysis pages.
- Wired a new runner `street-omaha-main.ts` optimized for Omaha computations by processing hands in smaller batches to avoid stalling the browser main thread during heavy combinatorics.

---
*PR created automatically by Jules for task [9125197903204288871](https://jules.google.com/task/9125197903204288871) started by @MikBin*