### PR TITLE
feat: Omaha Hi/Lo Street Analysis

### DIFF
--- a/poker-sym/dashboard/src/street-main.ts
+++ b/poker-sym/dashboard/src/street-main.ts
@@ -73,7 +73,7 @@ function runStreetSimulation(runs: number, seed?: number): Promise<StreetAnalysi
 }
 
 // Find dominant category
-const dominantCat = (stats: { categories: Record<string, number> }): { name: string; pct: number } => {
+const dominantCat = (stats: { categories: Record<string, number> | any }): { name: string; pct: number } => {
   let best = 'high card';
   let bestPct = 0;
   for (const cat of HAND_CATEGORY_NAMES) {
@@ -199,7 +199,7 @@ function renderSummaryTable(result: StreetAnalysisResult) {
 // Render category bars for a street
 const catBarClass = (cat: string): string => `cat-fill-${cat.replace(/ /g, '-')}`;
 
-function renderCategoryBars(stats: { categories: Record<string, number> }): string {
+function renderCategoryBars(stats: { categories: Record<string, number> | any }): string {
   let html = '<div class="cat-bars">';
   for (const cat of HAND_CATEGORY_NAMES) {
     const pct = stats.categories[cat];

--- a/poker-sym/dashboard/src/street-omaha-hi-lo-main.ts
+++ b/poker-sym/dashboard/src/street-omaha-hi-lo-main.ts
@@ -1,0 +1,178 @@
+import { fastHashesCreators } from '../../../src/pokerHashes7.js';
+import { enumerateOmahaStartingHands } from '../../src/hands/omaha.js';
+import { analyzeOmahaHiLoHandStreets } from '../../src/simulation/street-analysis-omaha-hilo.js';
+import { StreetHandResultHiLo, StreetAnalysisResultHiLo } from '../../src/simulation/types.js';
+
+// DOM
+const initStatus = document.getElementById('initStatus')!;
+const runsInput = document.getElementById('runs') as HTMLInputElement;
+const opponentsInput = document.getElementById('opponents') as HTMLInputElement;
+const seedInput = document.getElementById('seed') as HTMLInputElement;
+const runBtn = document.getElementById('run') as HTMLButtonElement;
+const progressContainer = document.getElementById('progressContainer')!;
+const progressFill = document.getElementById('progressFill')!;
+const progressText = document.getElementById('progressText')!;
+const resultsDiv = document.getElementById('results')!;
+
+// Sort state
+let sortKey = 'flop-scoop';
+let sortDir: 'desc' | 'asc' = 'desc';
+
+// Init
+async function init() {
+  await new Promise((r) => setTimeout(r, 50));
+  fastHashesCreators.high();
+  fastHashesCreators.low8();
+  initStatus.textContent = '✓ Evaluator ready';
+  initStatus.classList.add('ready');
+  runBtn.disabled = false;
+}
+
+// Run simulation in chunks
+function runStreetSimulation(runs: number, opponents: number, seed?: number): Promise<StreetAnalysisResultHiLo> {
+  return new Promise((resolve) => {
+    const hands = enumerateOmahaStartingHands();
+    const results: StreetHandResultHiLo[] = [];
+    let i = 0;
+    const chunkSize = 3; // Keep small to not freeze the UI too long
+
+    function processChunk() {
+      const end = Math.min(i + chunkSize, hands.length);
+      for (; i < end; i++) {
+        const hand = hands[i]!;
+        const handSeed = seed != null ? seed + i : undefined;
+        const result = analyzeOmahaHiLoHandStreets(hand, runs, opponents, handSeed);
+        results.push(result);
+      }
+
+      const pct = (i / hands.length) * 100;
+      progressFill.style.width = pct + '%';
+      progressText.textContent = i + '/' + hands.length + ' hands (' + pct.toFixed(0) + '%)';
+
+      if (i < hands.length) {
+        setTimeout(processChunk, 0);
+      } else {
+        results.sort((a, b) => b.flop.scoopPct - a.flop.scoopPct); // Default sort
+        resolve({
+          gameType: 'omaha-hi-lo',
+          config: { runs, opponents, seed },
+          hands: results,
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }
+
+    processChunk();
+  });
+}
+
+const sortValue = (h: StreetHandResultHiLo, key: string): number => {
+  switch (key) {
+    case 'flop-hi': return h.flop.winHiPct;
+    case 'flop-lo': return h.flop.winLoPct;
+    case 'flop-scoop': return h.flop.scoopPct;
+    case 'turn-hi': return h.turn.winHiPct;
+    case 'turn-lo': return h.turn.winLoPct;
+    case 'turn-scoop': return h.turn.scoopPct;
+    case 'river-hi': return h.river.winHiPct;
+    case 'river-lo': return h.river.winLoPct;
+    case 'river-scoop': return h.river.scoopPct;
+    default: return h.flop.scoopPct;
+  }
+};
+
+const SORT_ARROW: Record<string, string> = { desc: ' ▼', asc: ' ▲' };
+
+function renderSummaryTable(result: StreetAnalysisResultHiLo) {
+  const indices = result.hands.map((_h, i) => i);
+  indices.sort((a, b) => {
+    const va = sortValue(result.hands[a]!, sortKey);
+    const vb = sortValue(result.hands[b]!, sortKey);
+    return sortDir === 'desc' ? vb - va : va - vb;
+  });
+
+  let html = '<table><thead><tr>';
+  html += '<th>#</th><th>Hand</th>';
+  for (const col of [
+    { key: 'flop-hi', label: 'Flop Hi%' },
+    { key: 'flop-lo', label: 'Flop Lo%' },
+    { key: 'flop-scoop', label: 'Flop Scoop%' },
+    { key: 'turn-hi', label: 'Turn Hi%' },
+    { key: 'turn-lo', label: 'Turn Lo%' },
+    { key: 'turn-scoop', label: 'Turn Scoop%' },
+    { key: 'river-hi', label: 'River Hi%' },
+    { key: 'river-lo', label: 'River Lo%' },
+    { key: 'river-scoop', label: 'River Scoop%' },
+  ]) {
+    const arrow = sortKey === col.key ? SORT_ARROW[sortDir] : '';
+    html += `<th class="sortable" data-sort="${col.key}">${col.label}${arrow}</th>`;
+  }
+  html += '</tr></thead><tbody>';
+
+  for (let rank = 0; rank < indices.length; rank++) {
+    const i = indices[rank]!;
+    const h = result.hands[i]!;
+
+    html += `<tr data-idx="${i}">`;
+    html += `<td class="num">${rank + 1}</td>`;
+    html += `<td class="hand-cell">${h.hand}</td>`;
+    html += `<td class="num">${h.flop.winHiPct.toFixed(1)}%</td>`;
+    html += `<td class="num">${h.flop.winLoPct.toFixed(1)}%</td>`;
+    html += `<td class="num" style="color: #a855f7; font-weight: 600;">${h.flop.scoopPct.toFixed(1)}%</td>`;
+    html += `<td class="num">${h.turn.winHiPct.toFixed(1)}%</td>`;
+    html += `<td class="num">${h.turn.winLoPct.toFixed(1)}%</td>`;
+    html += `<td class="num" style="color: #a855f7; font-weight: 600;">${h.turn.scoopPct.toFixed(1)}%</td>`;
+    html += `<td class="num">${h.river.winHiPct.toFixed(1)}%</td>`;
+    html += `<td class="num">${h.river.winLoPct.toFixed(1)}%</td>`;
+    html += `<td class="num" style="color: #a855f7; font-weight: 600;">${h.river.scoopPct.toFixed(1)}%</td>`;
+    html += '</tr>';
+  }
+
+  html += '</tbody></table>';
+  resultsDiv.innerHTML = html;
+
+  resultsDiv.querySelectorAll('th.sortable').forEach((th) => {
+    th.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const key = (th as HTMLElement).dataset.sort!;
+      if (sortKey === key) {
+        sortDir = sortDir === 'desc' ? 'asc' : 'desc';
+      } else {
+        sortKey = key;
+        sortDir = 'desc';
+      }
+      renderSummaryTable(result);
+    });
+  });
+}
+
+runBtn.addEventListener('click', async () => {
+  const runs = parseInt(runsInput.value, 10) || 1000;
+  const opponents = parseInt(opponentsInput.value, 10) || 1;
+  const seedVal = seedInput.value ? parseInt(seedInput.value, 10) : undefined;
+
+  runBtn.disabled = true;
+  runBtn.textContent = 'Running...';
+  progressContainer.classList.add('active');
+  progressFill.style.width = '0%';
+  progressText.textContent = 'Starting...';
+  resultsDiv.innerHTML = '';
+
+  const startTime = performance.now();
+  const result = await runStreetSimulation(
+    Math.max(10, Math.min(100000, runs)),
+    Math.max(1, Math.min(9, opponents)),
+    seedVal
+  );
+  const elapsed = ((performance.now() - startTime) / 1000).toFixed(1);
+
+  progressFill.style.width = '100%';
+  progressText.textContent = '✓ Completed in ' + elapsed + 's';
+
+  renderSummaryTable(result);
+
+  runBtn.disabled = false;
+  runBtn.textContent = 'Run Street Analysis';
+});
+
+init();

--- a/poker-sym/dashboard/street-omaha-hi-lo.html
+++ b/poker-sym/dashboard/street-omaha-hi-lo.html
@@ -19,29 +19,112 @@
     .nav a { color: #3b82f6; text-decoration: none; font-size: 0.85rem; }
     .nav a:hover { text-decoration: underline; }
 
-    .coming-soon {
-      max-width: 500px;
-      margin: 4rem auto;
-      text-align: center;
+    .controls {
+      max-width: 700px;
+      margin: 0 auto 1.5rem;
+      display: flex;
+      gap: 1rem;
+      align-items: end;
+      flex-wrap: wrap;
+      justify-content: center;
     }
-    .coming-soon-icon { font-size: 4rem; margin-bottom: 1rem; }
-    .coming-soon h2 { font-size: 1.5rem; color: #f1f5f9; margin-bottom: 0.5rem; }
-    .coming-soon p { color: #94a3b8; line-height: 1.6; font-size: 0.95rem; }
-    .badge {
-      display: inline-block;
-      background: #8b5cf622;
-      color: #8b5cf6;
-      padding: 0.3rem 1rem;
-      border-radius: 999px;
-      font-size: 0.8rem;
+    .field { display: flex; flex-direction: column; gap: 0.25rem; }
+    .field label { font-size: 0.75rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.05em; }
+    .field input {
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      padding: 0.5rem 0.75rem;
+      color: #f1f5f9;
+      font-size: 1rem;
+      width: 120px;
+    }
+    .field input:focus { outline: none; border-color: #3b82f6; }
+
+    button#run {
+      background: #8b5cf6;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      padding: 0.55rem 1.5rem;
+      font-size: 1rem;
+      cursor: pointer;
       font-weight: 600;
-      margin-top: 1.5rem;
+      transition: background 0.2s;
     }
+    button#run:hover { background: #7c3aed; }
+    button#run:disabled { background: #475569; cursor: not-allowed; }
+
+    .progress-container {
+      max-width: 700px;
+      margin: 0 auto 1rem;
+      display: none;
+    }
+    .progress-container.active { display: block; }
+    .progress-bar-bg {
+      background: #1e293b;
+      border-radius: 999px;
+      height: 8px;
+      overflow: hidden;
+    }
+    .progress-bar-fill {
+      background: #8b5cf6;
+      height: 100%;
+      width: 0%;
+      transition: width 0.15s;
+      border-radius: 999px;
+    }
+    .progress-text {
+      text-align: center;
+      font-size: 0.8rem;
+      color: #94a3b8;
+      margin-top: 0.25rem;
+    }
+
+    .init-status {
+      text-align: center;
+      font-size: 0.8rem;
+      color: #94a3b8;
+      margin-bottom: 0.5rem;
+    }
+    .init-status.ready { color: #22c55e; }
+
+    .results-container {
+      max-width: 1100px;
+      margin: 0 auto;
+      overflow-x: auto;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.8rem;
+    }
+    th {
+      background: #1e293b;
+      padding: 0.6rem 0.6rem;
+      text-align: left;
+      font-weight: 600;
+      color: #94a3b8;
+      text-transform: uppercase;
+      font-size: 0.65rem;
+      letter-spacing: 0.05em;
+      position: sticky;
+      top: 0;
+    }
+    th.sortable {
+      cursor: pointer;
+      user-select: none;
+    }
+    th.sortable:hover { color: #e2e8f0; }
+    td { padding: 0.4rem 0.6rem; border-bottom: 1px solid #1e293b; }
+    tr:hover td { background: #1e293b44; }
+    .hand-cell { font-weight: 700; font-family: 'Courier New', monospace; font-size: 0.95rem; }
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
   </style>
 </head>
 <body>
   <h1>♠ poker-sym — Street Analysis ♥</h1>
-  <p class="subtitle">Omaha Hi/Lo — Street-by-Street Analysis</p>
+  <p class="subtitle">Flop / Turn / River Evolution — Omaha Hi/Lo Starting Hands</p>
   <div class="nav">
     <a href="index.html">🏠 Home</a><span class="sep" style="color:#475569;margin:0 0.3rem">·</span>
     <a href="street.html">Hold'em</a><span class="sep" style="color:#475569;margin:0 0.3rem">·</span>
@@ -52,12 +135,33 @@
     <a href="street-razz.html">Razz</a>
   </div>
 
-  <div class="coming-soon">
-    <div class="coming-soon-icon">🔀</div>
-    <h2>Omaha Hi/Lo — Street Analysis</h2>
-    <p>Track how each Omaha Hi/Lo starting hand evolves through the Flop, Turn, and River with scoop/split equity distributions, high and low hand category breakdowns.</p>
-    <div class="badge">🚧 Coming Soon</div>
+  <div id="initStatus" class="init-status">Initializing evaluator...</div>
+
+  <div class="controls">
+    <div class="field">
+      <label for="runs">Runs / Hand</label>
+      <input type="number" id="runs" value="500" min="10" max="100000" step="100" />
+    </div>
+    <div class="field">
+      <label for="opponents">Opponents</label>
+      <input type="number" id="opponents" value="1" min="1" max="9" step="1" />
+    </div>
+    <div class="field">
+      <label for="seed">Seed</label>
+      <input type="number" id="seed" value="" min="0" placeholder="random" />
+    </div>
+    <button id="run" disabled>Run Street Analysis</button>
   </div>
+
+  <div id="progressContainer" class="progress-container">
+    <div class="progress-bar-bg">
+      <div id="progressFill" class="progress-bar-fill"></div>
+    </div>
+    <div id="progressText" class="progress-text"></div>
+  </div>
+
+  <div id="results" class="results-container"></div>
+
+  <script type="module" src="/src/street-omaha-hi-lo-main.ts"></script>
 </body>
 </html>
-</write_to_file>

--- a/poker-sym/dashboard/tsconfig.json
+++ b/poker-sym/dashboard/tsconfig.json
@@ -10,7 +10,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"]
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@poker-sym/*": ["../src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/poker-sym/dashboard/vite.config.ts
+++ b/poker-sym/dashboard/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         'stud-hi-lo': resolve(__dirname, 'stud-hi-lo.html'),
         razz: resolve(__dirname, 'razz.html'),
         street: resolve(__dirname, 'street.html'),
+        'street-omaha-hi-lo': resolve(__dirname, 'street-omaha-hi-lo.html'),
       },
     },
   },

--- a/poker-sym/package-lock.json
+++ b/poker-sym/package-lock.json
@@ -21,6 +21,7 @@
       }
     },
     "..": {
+      "name": "gamblingjs",
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {

--- a/poker-sym/src/simulation/street-analysis-omaha-hilo.ts
+++ b/poker-sym/src/simulation/street-analysis-omaha-hilo.ts
@@ -1,0 +1,175 @@
+import { SeedableRNG } from '../utils/rng.js';
+import { makeDeck } from '../utils/deck.js';
+import { HandGroup } from '../hands/types.js';
+import { StreetHandResultHiLo, StreetStatsHiLo } from './types.js';
+import { handOfFiveEvalHiLow8Indexed } from '../../../src/pokerEvaluator5.js';
+import { hiLowRank } from '../../../src/interfaces.js';
+
+// Helper to get combinations
+function combinations2of4(cards: number[]): number[][] {
+  const result: number[][] = [];
+  for (let i = 0; i < 4; i++) {
+    for (let j = i + 1; j < 4; j++) {
+      result.push([cards[i]!, cards[j]!]);
+    }
+  }
+  return result;
+}
+
+function combinations3ofN(cards: number[]): number[][] {
+  const n = cards.length;
+  const result: number[][] = [];
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      for (let k = j + 1; k < n; k++) {
+        result.push([cards[i]!, cards[j]!, cards[k]!]);
+      }
+    }
+  }
+  return result;
+}
+
+function bestOmahaHiLoHand(holeCards: number[], board: number[]): hiLowRank {
+  let bestHi = -Infinity;
+  let bestLo = -1;
+
+  const holeCombos = combinations2of4(holeCards);
+  const boardCombos = combinations3ofN(board);
+
+  for (const hc of holeCombos) {
+    for (const bc of boardCombos) {
+      const score = handOfFiveEvalHiLow8Indexed(hc[0]!, hc[1]!, bc[0]!, bc[1]!, bc[2]!);
+      if (score.hi > bestHi) bestHi = score.hi;
+      if (score.low !== -1) {
+        if (bestLo === -1 || score.low > bestLo) {
+          bestLo = score.low;
+        }
+      }
+    }
+  }
+  return { hi: bestHi, low: bestLo };
+}
+
+interface StreetRunStats {
+  winHi: number;
+  winLo: number;
+  scoop: boolean;
+  ourHiRank: number;
+  ourLoRank: number;
+}
+
+function evaluateStreet(ourHoleCards: number[], oppHands: number[][], board: number[]): StreetRunStats {
+  const ourScore = bestOmahaHiLoHand(ourHoleCards, board);
+
+  let bestOpponentHi = -1;
+  let bestOpponentLo = -1;
+  let opponentLoPossible = false;
+
+  for (const opp of oppHands) {
+    const oppScore = bestOmahaHiLoHand(opp, board);
+    if (oppScore.hi > bestOpponentHi) bestOpponentHi = oppScore.hi;
+    if (oppScore.low !== -1) {
+      opponentLoPossible = true;
+      if (oppScore.low > bestOpponentLo) bestOpponentLo = oppScore.low;
+    }
+  }
+
+  let winHi = 0;
+  let winLo = 0;
+  const isLoPossibleForAnyone = ourScore.low !== -1 || opponentLoPossible;
+
+  if (ourScore.hi > bestOpponentHi) winHi = 1;
+  else if (ourScore.hi === bestOpponentHi) winHi = 0.5;
+
+  if (isLoPossibleForAnyone) {
+    if (ourScore.low !== -1) {
+      if (ourScore.low > bestOpponentLo) winLo = 1;
+      else if (ourScore.low === bestOpponentLo) winLo = 0.5;
+    }
+  }
+
+  const equityHi = winHi * (isLoPossibleForAnyone ? 0.5 : 1.0);
+  const equityLo = isLoPossibleForAnyone ? (winLo * 0.5) : 0;
+  const totalEquity = equityHi + equityLo;
+
+  return {
+    winHi,
+    winLo,
+    scoop: totalEquity === 1.0,
+    ourHiRank: ourScore.hi,
+    ourLoRank: ourScore.low,
+  };
+}
+
+function aggregateStats(runs: number, stats: StreetRunStats[]): StreetStatsHiLo {
+  let totalWinHi = 0;
+  let totalWinLo = 0;
+  let totalScoop = 0;
+  let totalHiRank = 0;
+  let totalLoRank = 0;
+  let validLoRuns = 0;
+
+  for (const s of stats) {
+    totalWinHi += s.winHi;
+    totalWinLo += s.winLo;
+    if (s.scoop) totalScoop++;
+    totalHiRank += s.ourHiRank;
+    if (s.ourLoRank !== -1) {
+      totalLoRank += s.ourLoRank;
+      validLoRuns++;
+    }
+  }
+
+  return {
+    winHiPct: (totalWinHi / runs) * 100,
+    winLoPct: (totalWinLo / runs) * 100,
+    scoopPct: (totalScoop / runs) * 100,
+    averageHighRank: totalHiRank / runs,
+    averageLowRank: validLoRuns > 0 ? totalLoRank / validLoRuns : undefined,
+  };
+}
+
+export const analyzeOmahaHiLoHandStreets = (
+  hand: HandGroup,
+  runs: number,
+  opponents: number,
+  seed?: number
+): StreetHandResultHiLo => {
+  const rng = new SeedableRNG(seed ?? Date.now());
+  const deck = makeDeck(hand.cards);
+
+  const actualOpponents = opponents > 0 ? opponents : 1; // Default to 1 opponent for scoop/win metrics
+
+  const flopStats: StreetRunStats[] = [];
+  const turnStats: StreetRunStats[] = [];
+  const riverStats: StreetRunStats[] = [];
+
+  for (let i = 0; i < runs; i++) {
+    const d = [...deck];
+    for (let j = d.length - 1; j > 0; j--) {
+      const k = rng.nextInt(j + 1);
+      [d[j], d[k]] = [d[k]!, d[j]!];
+    }
+
+    const totalNeeded = actualOpponents * 4 + 5;
+    const dealt = d.slice(0, totalNeeded);
+
+    const opponentHands: number[][] = [];
+    for (let j = 0; j < actualOpponents; j++) {
+      opponentHands.push([dealt[j * 4]!, dealt[j * 4 + 1]!, dealt[j * 4 + 2]!, dealt[j * 4 + 3]!]);
+    }
+
+    const board = dealt.slice(actualOpponents * 4, actualOpponents * 4 + 5);
+
+    flopStats.push(evaluateStreet(hand.cards, opponentHands, board.slice(0, 3)));
+    turnStats.push(evaluateStreet(hand.cards, opponentHands, board.slice(0, 4)));
+    riverStats.push(evaluateStreet(hand.cards, opponentHands, board.slice(0, 5)));
+  }
+
+  return {
+    hand: hand.key,
+    flop: aggregateStats(runs, flopStats),
+    turn: aggregateStats(runs, turnStats),
+    river: aggregateStats(runs, riverStats),
+  };
+};

--- a/poker-sym/src/simulation/types.ts
+++ b/poker-sym/src/simulation/types.ts
@@ -157,6 +157,34 @@ export interface StreetAnalysisResult {
   timestamp: string;
 }
 
+// ─── Omaha Hi/Lo Street Analysis Types ───────────────────────────────
+
+export interface StreetStatsHiLo {
+  winHiPct: number;
+  winLoPct: number;
+  scoopPct: number;
+  averageHighRank: number;
+  averageLowRank?: number;
+}
+
+export interface StreetHandResultHiLo {
+  hand: string;
+  flop: StreetStatsHiLo;
+  turn: StreetStatsHiLo;
+  river: StreetStatsHiLo;
+}
+
+export interface StreetAnalysisResultHiLo {
+  gameType: 'omaha-hi-lo';
+  config: {
+    runs: number;
+    opponents: number;
+    seed?: number;
+  };
+  hands: StreetHandResultHiLo[];
+  timestamp: string;
+}
+
 /** Category names in order matching handsRankingDelimiter_5cards thresholds. */
 export const HAND_CATEGORY_NAMES = [
   'high card',


### PR DESCRIPTION
Implemented the Street-by-Street analysis page for Omaha Hi/Lo poker in the poker-sym dashboard. This evaluates Omaha starting hands through the Flop, Turn, and River, calculating High win %, Low win %, and Scoop % against variable numbers of opponents.

---
*PR created automatically by Jules for task [5738425874367659619](https://jules.google.com/task/5738425874367659619) started by @MikBin*